### PR TITLE
Task-54499: Update poll drawer UI

### DIFF
--- a/poll-webapp/src/main/resources/locale/portlet/Poll_en.properties
+++ b/poll-webapp/src/main/resources/locale/portlet/Poll_en.properties
@@ -5,7 +5,7 @@
 composer.poll.create=Create a Poll
 composer.poll.create.drawer.description=Add a Poll to your Activity
 composer.poll.create.drawer.field.question=Ask something ...
-composer.poll.create.drawer.field.option=Option {0}
-composer.poll.create.drawer.option.add=Add option
+composer.poll.create.drawer.field.option=Choice {0}
+composer.poll.create.drawer.field.option.optional=Choice {0} (optional)
 composer.poll.create.drawer.action.create=Create
 composer.poll.create.drawer.action.cancel=Cancel

--- a/poll-webapp/src/main/webapp/skin/less/poll.less
+++ b/poll-webapp/src/main/webapp/skin/less/poll.less
@@ -16,9 +16,9 @@
   }
 }
 
-#createPollDrawer{
-  .createPollDrawerContent{
-    .custom-poll-textarea{
+#createPollDrawer {
+  .createPollDrawerContent {
+    .custom-poll-textarea {
       textarea{
         padding: 8px 8px;
         box-shadow: none;

--- a/poll-webapp/src/main/webapp/skin/less/poll.less
+++ b/poll-webapp/src/main/webapp/skin/less/poll.less
@@ -19,7 +19,7 @@
 #createPollDrawer {
   .createPollDrawerContent {
     .custom-poll-textarea {
-      textarea{
+      textarea {
         padding: 8px 8px;
         box-shadow: none;
       }

--- a/poll-webapp/src/main/webapp/skin/less/poll.less
+++ b/poll-webapp/src/main/webapp/skin/less/poll.less
@@ -18,32 +18,10 @@
 
 #createPollDrawer{
   .createPollDrawerContent{
-    .custom-textarea{
-      border: none;
-      padding: 0px;
-      .v-counter.theme--light {
-        display: flex;
-        justify-content: flex-end;
-      }
-      textarea, textarea:active{
-          box-shadow: none !important;
-          padding-left: 0px;
-          border: none !important;
-        }
-      fieldset{
-        color: rgba(0, 0, 0, 0.12) !important;
-      }
-    }
-    // on focus fieldset above textarea
-    .v-text-field--outlined.v-input--is-focused fieldset{
-      box-shadow:  0 1px 1px rgba(0,0,0,.075), 0 0 5px !important;
-      transition-duration: 0.3s;
-      transition-property: border, box-shadow;
-    }
-    .removeOptionButton{
-      width: 25px;
-      .removeOptionButtonIcon{
-        color: @mediumGrey
+    .custom-poll-textarea{
+      textarea{
+        padding: 8px 8px;
+        box-shadow: none;
       }
     }
   }

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
@@ -44,9 +44,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 rows="3"
                 row-height="15"
                 :max-length="MAX_LENGTH"
-                :placeholder="$t('composer.poll.create.drawer.field.question')"
-                class="custom-poll-textarea pt-0 mb-3"
-                />
+                :placeholder="questionPlaceholder"
+                class="custom-poll-textarea pt-0 mb-3" />
             </v-list-item>
             
             <v-list-item
@@ -60,10 +59,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 row-height="15"
                 :max-length="MAX_LENGTH"
                 class="custom-poll-textarea pt-0 mb-3"
-                :placeholder="$t(`composer.poll.create.drawer.field.option${!option.required ? '.optional' : ''}`, {0: option.id})"
-                />
+                :placeholder="$t(`composer.poll.create.drawer.field.option${!option.required ? '.optional' : ''}`, {0: option.id})" />
             </v-list-item>
-
           </v-list>
         </v-form>
       </div>
@@ -81,7 +78,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           class="px-8 primary btn no-box-shadow"
           button
           large
-          :disabled="!checkPollFields"
+          :disabled="disableCreatePoll"
           @click="createPoll">
           {{ $t('composer.poll.create.drawer.action.create') }}
         </v-btn>
@@ -95,7 +92,7 @@ export default {
 
   data(){
     return {
-      MAX_LENGTH: 1000,
+      MAX_LENGTH: 10,
       poll: {},
       options: [
         {
@@ -131,9 +128,12 @@ export default {
     checkPollOptions(){
       return this.options && this.options.length !== 0 && this.options.slice(0,2).every(option => option.data !== null && option.data !== '' && option.data.length <= this.MAX_LENGTH );
     },
-    checkPollFields(){
-      return this.poll.question && this.poll.question !==null && this.poll.question.length <= this.MAX_LENGTH && this.checkPollOptions;
+    disableCreatePoll(){
+      return !(Object.values(this.poll).length !== 0 && this.poll.question && this.poll.question.length <= this.MAX_LENGTH && this.checkPollOptions);
     },
+    questionPlaceholder(){
+      return this.$t('composer.poll.create.drawer.field.question');
+    }
   },
   methods: {
     openDrawer(){
@@ -144,19 +144,10 @@ export default {
       this.resetDrawer();
     },
     createPoll(){
-      this.$refs.createPollDrawer.close();
+      this.closeDrawer();
     },
     resetDrawer(){
       //reset drawer fields
-    },
-    addOption(){
-      this.options.push({id: this.options.length + 1, removable: true,data: {}});
-    },
-    removeOption(option){
-      this.options.splice(this.options.indexOf(option), 1);
-      this.options.forEach((element,index) => {
-        element.id = index +1;
-      });
     }
   }
 };

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
@@ -92,7 +92,7 @@ export default {
 
   data(){
     return {
-      MAX_LENGTH: 10,
+      MAX_LENGTH: 1000,
       poll: {},
       options: [
         {

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
@@ -39,16 +39,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <v-list-item
               class="px-0"
               dense>
-              <v-textarea
-                counter
-                maxlength="1000"
-                auto-grow
-                outlined
-                rows="1"
+              <extended-textarea
+                rows="3"
                 row-height="15"
-                class="custom-textarea mb-3"
-                :placeholder="`${$t('composer.poll.create.drawer.field.question')}`"
-                type="text" />
+                max-length="10"
+                :placeholder="$t('composer.poll.create.drawer.field.question')"
+                class="custom-poll-textarea pt-0 mb-3 "
+                />
             </v-list-item>
             
             <v-list-item
@@ -56,35 +53,15 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               :key="index"
               class="px-0 d-flex"
               dense>
-              <div class=" float-left mb-8 me-3 removeOptionButton">
-                <v-btn
-                  v-if="option.removable"
-                  icon
-                  @click="removeOption(option)">
-                  <em class="fas fa-trash-alt removeOptionButtonIcon"></em>
-                </v-btn>
-              </div> 
-              <v-textarea
-                counter
-                maxlength="1000"
-                auto-grow
-                outlined
-                rows="1"
+              <extended-textarea
+                rows="2"
                 row-height="15"
-                class="custom-textarea mb-3"
-                :placeholder="$t('composer.poll.create.drawer.field.option', {0: option.id})"
-                type="text" />
+                max-length="10"
+                class="custom-poll-textarea pt-0 mb-3"
+                :placeholder="$t(`composer.poll.create.drawer.field.option${!option.required ? '.optional' : ''}`, {0: option.id})"
+                />
             </v-list-item>
 
-            <v-list-item
-              class="px-0 d-flex justify-end"
-              dense>
-              <div class="d-flex flex-row ">
-                <a class="text-subtitle-1 font-weight-bold" @click="addOption">
-                  + {{ $t('composer.poll.create.drawer.option.add') }}
-                </a>
-              </div>
-            </v-list-item>
           </v-list>
         </v-form>
       </div>
@@ -118,17 +95,22 @@ export default {
       options: [
         {
           id: 1,
-          removable: false,
+          required: true,
           data: {}
         },
         {
           id: 2,
-          removable: false,
+          required: true,
           data: {}
         },
         {
           id: 3,
-          removable: true,
+          required: false,
+          data: {}
+        },
+        {
+          id: 4,
+          required: false,
           data: {}
         }
       ]

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
@@ -40,11 +40,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               class="px-0"
               dense>
               <extended-textarea
+                v-model.trim="poll.question"
                 rows="3"
                 row-height="15"
-                max-length="10"
+                :max-length="MAX_LENGTH"
                 :placeholder="$t('composer.poll.create.drawer.field.question')"
-                class="custom-poll-textarea pt-0 mb-3 "
+                class="custom-poll-textarea pt-0 mb-3"
                 />
             </v-list-item>
             
@@ -54,9 +55,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               class="px-0 d-flex"
               dense>
               <extended-textarea
+                v-model.trim="options[index].data"
                 rows="2"
                 row-height="15"
-                max-length="10"
+                :max-length="MAX_LENGTH"
                 class="custom-poll-textarea pt-0 mb-3"
                 :placeholder="$t(`composer.poll.create.drawer.field.option${!option.required ? '.optional' : ''}`, {0: option.id})"
                 />
@@ -79,6 +81,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           class="px-8 primary btn no-box-shadow"
           button
           large
+          :disabled="!checkPollFields"
           @click="createPoll">
           {{ $t('composer.poll.create.drawer.action.create') }}
         </v-btn>
@@ -92,26 +95,28 @@ export default {
 
   data(){
     return {
+      MAX_LENGTH: 1000,
+      poll: {},
       options: [
         {
           id: 1,
           required: true,
-          data: {}
+          data: null
         },
         {
           id: 2,
           required: true,
-          data: {}
+          data: null
         },
         {
           id: 3,
           required: false,
-          data: {}
+          data: null
         },
         {
           id: 4,
           required: false,
-          data: {}
+          data: null
         }
       ]
     };
@@ -122,6 +127,12 @@ export default {
     },
     drawerWidth() {
       return !this.isMobile ? '33%' : '420';
+    },
+    checkPollOptions(){
+      return this.options && this.options.length !== 0 && this.options.slice(0,2).every(option => option.data !== null && option.data !== '' && option.data.length <= this.MAX_LENGTH );
+    },
+    checkPollFields(){
+      return this.poll.question && this.poll.question !==null && this.poll.question.length <= this.MAX_LENGTH && this.checkPollOptions;
     },
   },
   methods: {

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
@@ -125,11 +125,14 @@ export default {
     drawerWidth() {
       return !this.isMobile ? '33%' : '420';
     },
-    checkPollOptions(){
-      return this.options && this.options.length !== 0 && this.options.slice(0,2).every(option => option.data !== null && option.data !== '' && option.data.length <= this.MAX_LENGTH );
+    checkPollOptionalOptions(){
+      return this.options.slice(-2).every(option => !option.data || option.data.length <= this.MAX_LENGTH );
+    },
+    checkPollAllOptions(){
+      return this.options && this.options.length !== 0 && this.options.slice(0,2).every(option => option.data !== null && option.data !== '' && option.data.length <= this.MAX_LENGTH ) && this.checkPollOptionalOptions;
     },
     disableCreatePoll(){
-      return !(Object.values(this.poll).length !== 0 && this.poll.question && this.poll.question.length <= this.MAX_LENGTH && this.checkPollOptions);
+      return !(Object.values(this.poll).length !== 0 && this.poll.question && this.poll.question.length <= this.MAX_LENGTH && this.checkPollAllOptions);
     },
     questionPlaceholder(){
       return this.$t('composer.poll.create.drawer.field.question');


### PR DESCRIPTION
The poll drawer UI is updated:

- Remove the dynamic options list managed by delete/add buttons and keep just 2 required options and 2 optional ones
- Use `extended-textarea` eXo common component instead of  `v-textarea` **vuetify** standard component.