### PR TITLE
Task-53706: Edit a poll before posting

### DIFF
--- a/poll-webapp/src/main/resources/locale/portlet/Poll_en.properties
+++ b/poll-webapp/src/main/resources/locale/portlet/Poll_en.properties
@@ -2,7 +2,7 @@
 #                                    Create Poll Composer                           #
 #####################################################################################
 
-composer.poll.create=Create a Poll
+composer.poll.create.drawer.label=Create a Poll
 composer.poll.create.drawer.description=Add a Poll to your Activity
 composer.poll.create.drawer.field.question=Ask something ...
 composer.poll.create.drawer.field.option=Choice {0}
@@ -13,4 +13,7 @@ composer.poll.create.drawer.field.duration.threeDays=3 Days
 composer.poll.create.drawer.field.duration.oneWeek=1 Week
 composer.poll.create.drawer.field.duration.twoWeeks=2 Weeks
 composer.poll.create.drawer.action.create=Create
+composer.poll.create.drawer.action.update=Update
 composer.poll.create.drawer.action.cancel=Cancel
+composer.poll.update.drawer.label=You created a Poll !
+composer.poll.update.drawer.description=Click here to edit the Poll you just created !

--- a/poll-webapp/src/main/webapp/images/circle-checked.svg
+++ b/poll-webapp/src/main/webapp/images/circle-checked.svg
@@ -1,0 +1,10 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 512 512"
+  height="16"
+  width="16"
+  fill="#46a546">
+  <!--! Font Awesome Pro 6.0.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+  <path
+    d="M0 256C0 114.6 114.6 0 256 0C397.4 0 512 114.6 512 256C512 397.4 397.4 512 256 512C114.6 512 0 397.4 0 256zM371.8 211.8C382.7 200.9 382.7 183.1 371.8 172.2C360.9 161.3 343.1 161.3 332.2 172.2L224 280.4L179.8 236.2C168.9 225.3 151.1 225.3 140.2 236.2C129.3 247.1 129.3 264.9 140.2 275.8L204.2 339.8C215.1 350.7 232.9 350.7 243.8 339.8L371.8 211.8z"></path>
+</svg>

--- a/poll-webapp/src/main/webapp/skin/less/poll.less
+++ b/poll-webapp/src/main/webapp/skin/less/poll.less
@@ -13,6 +13,12 @@
         background-size: 40px;
       }
     }
+    .actionItemDescription {
+      .actionLabel.createdPollIcon::after {
+          content: url('@{images-path}/circle-checked.svg');
+          margin-left: 20px;
+      }
+    }
   }
 }
 

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollComposer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollComposer.vue
@@ -29,14 +29,18 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </div>
       </div>
     </div>
-    <create-poll-drawer ref="createPollDrawer" />
+    <create-poll-drawer
+      ref="createPollDrawer"
+      :activity-poll="activityPoll"
+      @poll-saved="savePoll" />
   </div>
 </template>
 <script>
 export default {
   data(){
     return {
-      pollAction: 'create'
+      pollAction: 'create',
+      activityPoll: {}
     };
   },
   computed: {
@@ -59,6 +63,11 @@ export default {
     openCreatePollDrawer() {
       this.$refs.createPollDrawer.openDrawer();
     },
+    savePoll(poll){
+      Object.assign(this.activityPoll,poll);
+      this.pollAction = 'update';
+      document.dispatchEvent(new CustomEvent('activity-composer-edited'));
+    }
   },
 };
 </script> 

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollComposer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollComposer.vue
@@ -31,16 +31,16 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </div>
     <create-poll-drawer
       ref="createPollDrawer"
-      :activity-poll="activityPoll"
-      @poll-saved="savePoll" />
+      :saved-poll="savedPoll"
+      @poll-created="createPoll" />
   </div>
 </template>
 <script>
 export default {
-  data(){
+  data() {
     return {
       pollAction: 'create',
-      activityPoll: {}
+      savedPoll: {}
     };
   },
   computed: {
@@ -54,17 +54,12 @@ export default {
       return this.pollAction === 'update' ? 'createdPollIcon' : '';
     }
   },
-  mounted(){
-    this.$root.$on('poll-created',(state)=>{
-      this.pollAction = state ? 'update' : 'create';
-    });
-  },
   methods: {
     openCreatePollDrawer() {
       this.$refs.createPollDrawer.openDrawer();
     },
-    savePoll(poll){
-      Object.assign(this.activityPoll,poll);
+    createPoll(poll) {
+      Object.assign(this.savedPoll, poll);
       this.pollAction = 'update';
       document.dispatchEvent(new CustomEvent('activity-composer-edited'));
     }

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollComposer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollComposer.vue
@@ -1,0 +1,43 @@
+<!--
+This file is part of the Meeds project (https://meeds.io/).
+ 
+Copyright (C) 2022 Meeds Association contact@meeds.io
+ 
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+ 
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<template>
+  <div>
+    <div class="actionItem" @click="openCreatePollDrawer">
+      <div class="actionItemIcon">
+        <div class="createPollComposerIcon"></div>
+      </div>
+      <div class="actionItemDescription">
+        <div class="actionLabel">{{ $t('composer.poll.create.drawer.label') }}</div>
+        <div class="actionDescription">
+          <p>{{ $t('composer.poll.create.drawer.description') }}</p>
+        </div>
+      </div>
+    </div>
+    <create-poll-drawer ref="createPollDrawer" />
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    openCreatePollDrawer() {
+      this.$refs.createPollDrawer.openDrawer();
+    },
+  },
+};
+</script> 

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollComposer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollComposer.vue
@@ -23,9 +23,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <div class="createPollComposerIcon"></div>
       </div>
       <div class="actionItemDescription">
-        <div class="actionLabel">{{ $t('composer.poll.create.drawer.label') }}</div>
+        <div :class="`actionLabel ${createdPollIcon}`"> {{ pollActionLabel }} </div>
         <div class="actionDescription">
-          <p>{{ $t('composer.poll.create.drawer.description') }}</p>
+          <p>{{ pollActionDescription }}</p>
         </div>
       </div>
     </div>
@@ -34,6 +34,27 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 </template>
 <script>
 export default {
+  data(){
+    return {
+      pollAction: 'create'
+    };
+  },
+  computed: {
+    pollActionLabel(){
+      return this.$t(`composer.poll.${this.pollAction}.drawer.label`);
+    },
+    pollActionDescription(){
+      return this.$t(`composer.poll.${this.pollAction}.drawer.description`);
+    },
+    createdPollIcon(){
+      return this.pollAction === 'update' ? 'createdPollIcon' : '';
+    }
+  },
+  mounted(){
+    this.$root.$on('poll-created',(state)=>{
+      this.pollAction = state ? 'update' : 'create';
+    });
+  },
   methods: {
     openCreatePollDrawer() {
       this.$refs.createPollDrawer.openDrawer();

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
@@ -26,7 +26,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     @closed="!pollCreated ? resetFields() : null">
     <template slot="title">
       <div class="createPollDrawerHeader">
-        <span>{{ $t('composer.poll.create') }}</span>
+        <span>{{ $t('composer.poll.create.drawer.label') }}</span>
       </div>
     </template>
     <template slot="content">
@@ -101,7 +101,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           large
           :disabled="disableCreatePoll"
           @click="createPoll">
-          {{ $t('composer.poll.create.drawer.action.create') }}
+          {{ $t(`composer.poll.create.drawer.action.${pollCreated ? 'update' : 'create'}`) }}
         </v-btn>
       </div>
     </template>
@@ -141,7 +141,13 @@ export default {
   },
   methods: {
     intializeDrawerFields(){
-      Object.assign(this.poll,{}),
+      document.dispatchEvent(new CustomEvent('poll-composer-button-text',{
+        detail: {
+          labelKey: 'composer.poll.create.drawer.label',
+          description: 'composer.poll.create.drawer.description' 
+        }
+      }));
+      this.poll = {};
       this.options = [
         {
           id: 1,
@@ -164,6 +170,7 @@ export default {
           data: null
         }
       ];
+      this.pollCreated = false;
 
     },
     resetFields(){
@@ -173,7 +180,6 @@ export default {
     openDrawer(){
       if (this.disableCreatePoll)
       {this.intializeDrawerFields();}
-      //this.pollCreated = false;
       this.$refs.createPollDrawer.open();
     },
     closeDrawer(addedPoll){
@@ -182,10 +188,16 @@ export default {
       this.$refs.createPollDrawer.close();
     },
     createPoll(){
-      if(!this.disableCreatePoll){
+      if (!this.disableCreatePoll) {
         this.poll.options = this.options;
         this.pollCreated = true;
         this.closeDrawer(this.poll);
+        document.dispatchEvent(new CustomEvent('poll-composer-button-text',{
+          detail: {
+            labelKey: 'composer.poll.update.drawer.label',
+            description: 'composer.poll.update.drawer.description' 
+          }
+        }));
       }
     },
   }

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
@@ -191,12 +191,14 @@ export default {
     },
     createPoll(){
       if (!this.disableCreatePoll) {
-        if (!this.poll.duration) {this.poll.duration = document.getElementById('pollSelectedDuration').value;}
+        if (!this.poll.duration) {
+          this.poll.duration = document.getElementById('pollSelectedDuration').value;
+        }
         
         this.poll.options = this.options;
         this.pollCreated = true;
 
-        this.$root.$emit('poll-created',true);
+        this.$root.$emit('poll-created', true);
         document.dispatchEvent(new CustomEvent('activity-composer-edited'));
 
         this.closeDrawer(this.poll);

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
@@ -112,7 +112,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <script>
 export default {
 
-  data(){
+  data() {
     return {
       MAX_LENGTH: 1000,
       poll: {},
@@ -121,8 +121,7 @@ export default {
     };
   },
   props: {
-    activityPoll: {
-      required: true,
+    savedPoll: {
       type: Object,
       default: null
     }
@@ -134,27 +133,27 @@ export default {
     drawerWidth() {
       return !this.isMobile ? '100%' : '420';
     },
-    checkPollOptionalOptions(){
+    checkPollOptionalOptions() {
       return this.options.slice(-2).every(option => !option.data || option.data.length <= this.MAX_LENGTH );
     },
-    checkPollAllOptions(){
+    checkPollAllOptions() {
       return this.options && this.options.length !== 0 && this.options.slice(0,2).every(option => option.data !== null && option.data !== '' && option.data.length <= this.MAX_LENGTH ) && this.checkPollOptionalOptions;
     },
-    disableCreatePoll(){
+    disableCreatePoll() {
       return !(Object.values(this.poll).length !== 0 && this.poll.question && this.poll.question.length <= this.MAX_LENGTH && this.checkPollAllOptions);
     },
-    questionPlaceholder(){
+    questionPlaceholder() {
       return this.$t('composer.poll.create.drawer.field.question');
     },
-    submitButton(){
+    submitButton() {
       return this.$t(`composer.poll.create.drawer.action.${this.pollCreated ? 'update' : 'create'}`);
     },
-    closeButton(){
+    closeButton() {
       return this.$t('composer.poll.create.drawer.action.cancel');
     }
   },
   methods: {
-    intializeDrawerFields(){
+    intializeDrawerFields() {
       this.poll = {};
       this.options = [
         {
@@ -181,20 +180,20 @@ export default {
       this.poll.duration = '1w';
       this.pollCreated = false;
     },
-    openDrawer(){
-      if (!Object.values(this.activityPoll).length){
+    openDrawer() {
+      if (!Object.values(this.savedPoll).length) {
         this.intializeDrawerFields();
       }
       else {
-        this.options = JSON.parse(JSON.stringify(this.activityPoll.options));
-        Object.assign(this.poll,JSON.parse(JSON.stringify(this.activityPoll)));
+        this.options = JSON.parse(JSON.stringify(this.savedPoll.options));
+        Object.assign(this.poll,JSON.parse(JSON.stringify(this.savedPoll)));
       }
       this.$refs.createPollDrawer.open();
     },
-    closeDrawer(){
+    closeDrawer() {
       this.$refs.createPollDrawer.close();
     },
-    createPoll(){
+    createPoll() {
       if (!this.disableCreatePoll) {
         if (!this.poll.duration) {
           this.poll.duration = document.getElementById('pollSelectedDuration').value;
@@ -202,7 +201,7 @@ export default {
         this.poll.options = this.options;
         this.pollCreated = true;
 
-        this.$emit('poll-saved',this.poll);
+        this.$emit('poll-created', this.poll);
         this.closeDrawer();
       }
     },

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
@@ -75,6 +75,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               class="px-0"
               dense>
               <select
+                id="pollSelectedDuration"
+                @change="getSelectedDuration"
                 class="ignore-vuetify-classes poll-select-duration flex-grow-1">
                 <option value="1d">{{ $t('composer.poll.create.drawer.field.duration.oneDay') }}</option>
                 <option value="3d">{{ $t('composer.poll.create.drawer.field.duration.threeDays') }}</option>
@@ -93,7 +95,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           button
           large
           @click="closeDrawer">
-          {{ $t('composer.poll.create.drawer.action.cancel') }}
+          {{ closeButton }}
         </v-btn>
         <v-btn
           class="px-8 primary btn no-box-shadow"
@@ -101,7 +103,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           large
           :disabled="disableCreatePoll"
           @click="createPoll">
-          {{ $t(`composer.poll.create.drawer.action.${pollCreated ? 'update' : 'create'}`) }}
+          {{ submitButton }}
         </v-btn>
       </div>
     </template>
@@ -137,16 +139,16 @@ export default {
     },
     questionPlaceholder(){
       return this.$t('composer.poll.create.drawer.field.question');
+    },
+    submitButton(){
+      return this.$t(`composer.poll.create.drawer.action.${this.pollCreated ? 'update' : 'create'}`);
+    },
+    closeButton(){
+      return this.$t('composer.poll.create.drawer.action.cancel');
     }
   },
   methods: {
     intializeDrawerFields(){
-      document.dispatchEvent(new CustomEvent('poll-composer-button-text',{
-        detail: {
-          labelKey: 'composer.poll.create.drawer.label',
-          description: 'composer.poll.create.drawer.description' 
-        }
-      }));
       this.poll = {};
       this.options = [
         {
@@ -189,16 +191,19 @@ export default {
     },
     createPoll(){
       if (!this.disableCreatePoll) {
+        if (!this.poll.duration) {this.poll.duration = document.getElementById('pollSelectedDuration').value;}
+        
         this.poll.options = this.options;
         this.pollCreated = true;
+
+        this.$root.$emit('poll-created',true);
+        document.dispatchEvent(new CustomEvent('activity-composer-edited'));
+
         this.closeDrawer(this.poll);
-        document.dispatchEvent(new CustomEvent('poll-composer-button-text',{
-          detail: {
-            labelKey: 'composer.poll.update.drawer.label',
-            description: 'composer.poll.update.drawer.description' 
-          }
-        }));
       }
+    },
+    getSelectedDuration({ target }){
+      this.poll.duration = target.value;
     },
   }
 };

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
@@ -22,8 +22,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     id="createPollDrawer"
     :drawer-width="drawerWidth"
     :right="!$vuetify.rtl"
-    disable-pull-to-refresh
-    @closed="!pollCreated ? resetFields() : null">
+    disable-pull-to-refresh>
     <template slot="title">
       <div class="createPollDrawerHeader">
         <span>{{ $t('composer.poll.create.drawer.label') }}</span>
@@ -76,11 +75,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               dense>
               <select
                 id="pollSelectedDuration"
-                @change="getSelectedDuration"
+                v-model="poll.duration"
                 class="ignore-vuetify-classes poll-select-duration flex-grow-1">
                 <option value="1d">{{ $t('composer.poll.create.drawer.field.duration.oneDay') }}</option>
                 <option value="3d">{{ $t('composer.poll.create.drawer.field.duration.threeDays') }}</option>
-                <option value="1w" selected>{{ $t('composer.poll.create.drawer.field.duration.oneWeek') }}</option>
+                <option value="1w">{{ $t('composer.poll.create.drawer.field.duration.oneWeek') }}</option>
                 <option value="2w">{{ $t('composer.poll.create.drawer.field.duration.twoWeeks') }}</option>
               </select>
             </v-list-item>
@@ -120,6 +119,13 @@ export default {
       options: [],
       pollCreated: false
     };
+  },
+  props: {
+    activityPoll: {
+      required: true,
+      type: Object,
+      default: null
+    }
   },
   computed: {
     isMobile() {
@@ -172,21 +178,20 @@ export default {
           data: null
         }
       ];
+      this.poll.duration = '1w';
       this.pollCreated = false;
-
-    },
-    resetFields(){
-      this.poll.question = null;
-      this.options = [];
     },
     openDrawer(){
-      if (this.disableCreatePoll)
-      {this.intializeDrawerFields();}
+      if (!Object.values(this.activityPoll).length){
+        this.intializeDrawerFields();
+      }
+      else {
+        this.options = JSON.parse(JSON.stringify(this.activityPoll.options));
+        Object.assign(this.poll,JSON.parse(JSON.stringify(this.activityPoll)));
+      }
       this.$refs.createPollDrawer.open();
     },
-    closeDrawer(addedPoll){
-      if (!addedPoll)
-      {this.resetFields();}
+    closeDrawer(){
       this.$refs.createPollDrawer.close();
     },
     createPoll(){
@@ -194,18 +199,12 @@ export default {
         if (!this.poll.duration) {
           this.poll.duration = document.getElementById('pollSelectedDuration').value;
         }
-        
         this.poll.options = this.options;
         this.pollCreated = true;
 
-        this.$root.$emit('poll-created', true);
-        document.dispatchEvent(new CustomEvent('activity-composer-edited'));
-
-        this.closeDrawer(this.poll);
+        this.$emit('poll-saved',this.poll);
+        this.closeDrawer();
       }
-    },
-    getSelectedDuration({ target }){
-      this.poll.duration = target.value;
     },
   }
 };

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollDrawer.vue
@@ -22,7 +22,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     id="createPollDrawer"
     :drawer-width="drawerWidth"
     :right="!$vuetify.rtl"
-    disable-pull-to-refresh>
+    disable-pull-to-refresh
+    @closed="!pollCreated ? resetFields() : null">
     <template slot="title">
       <div class="createPollDrawerHeader">
         <span>{{ $t('composer.poll.create') }}</span>
@@ -114,28 +115,8 @@ export default {
     return {
       MAX_LENGTH: 1000,
       poll: {},
-      options: [
-        {
-          id: 1,
-          required: true,
-          data: null
-        },
-        {
-          id: 2,
-          required: true,
-          data: null
-        },
-        {
-          id: 3,
-          required: false,
-          data: null
-        },
-        {
-          id: 4,
-          required: false,
-          data: null
-        }
-      ]
+      options: [],
+      pollCreated: false
     };
   },
   computed: {
@@ -159,19 +140,54 @@ export default {
     }
   },
   methods: {
+    intializeDrawerFields(){
+      Object.assign(this.poll,{}),
+      this.options = [
+        {
+          id: 1,
+          required: true,
+          data: null
+        },
+        {
+          id: 2,
+          required: true,
+          data: null
+        },
+        {
+          id: 3,
+          required: false,
+          data: null
+        },
+        {
+          id: 4,
+          required: false,
+          data: null
+        }
+      ];
+
+    },
+    resetFields(){
+      this.poll.question = null;
+      this.options = [];
+    },
     openDrawer(){
+      if (this.disableCreatePoll)
+      {this.intializeDrawerFields();}
+      //this.pollCreated = false;
       this.$refs.createPollDrawer.open();
     },
-    closeDrawer(){
+    closeDrawer(addedPoll){
+      if (!addedPoll)
+      {this.resetFields();}
       this.$refs.createPollDrawer.close();
-      this.resetDrawer();
     },
     createPoll(){
-      this.closeDrawer();
+      if(!this.disableCreatePoll){
+        this.poll.options = this.options;
+        this.pollCreated = true;
+        this.closeDrawer(this.poll);
+      }
     },
-    resetDrawer(){
-      //reset drawer fields
-    }
   }
 };
 </script>

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/initComponents.js
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/initComponents.js
@@ -17,9 +17,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import CreatePollDrawer from './components/CreatePollDrawer.vue';
+import CreatePollComposer from './components/CreatePollComposer.vue';
 
 const components = {
   'create-poll-drawer': CreatePollDrawer,
+  'create-poll-composer': CreatePollComposer,
 };
 
 for (const key in components) {

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/main.js
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/main.js
@@ -19,6 +19,12 @@
 import {initExtensions} from './pollExtensions.js';
 import './initComponents.js';
 
+// getting language of the PLF
+const lang = eXo.env.portal.language || 'en';
+// init Vue app when locale resources are ready
+const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Poll-${lang}.json`;
+// init Vue app when locale resources are ready
+exoi18n.loadLanguageAsync(lang, url).then(i18n => new Vue({i18n}));
 
 export function init() {
   initExtensions();

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/pollExtensions.js
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/pollExtensions.js
@@ -16,36 +16,12 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-const pollActivityComposerPlugin = {
-  key: 'poll',
-  rank: 40,
-  resourceBundle: 'locale.portlet.Poll',
-  labelKey: 'composer.poll.create.drawer.label',
-  description: 'composer.poll.create.drawer.description',
-  iconClass: 'createPollComposerIcon',
-  enabled: true,
-  component: {
-    name: 'create-poll-drawer',
-    props: {
-    },
-    model: {
-      value: [],
-      default: []
-    },
-    events: []
-  },
-  onExecute: (createPollDrawerComponent) => {
-    createPollDrawerComponent.openDrawer();
-  }
-};
 
 export function initExtensions() {
-  extensionRegistry.registerExtension('ActivityComposer', 'activity-composer-action', pollActivityComposerPlugin);
-
-  document.addEventListener('poll-composer-button-text',(data)=>{
-    pollActivityComposerPlugin.labelKey = data.detail.labelKey;
-    pollActivityComposerPlugin.description = data.detail.description;
-  
+  extensionRegistry.registerComponent('ActivityComposerFooterAction', 'activity-composer-footer-action', {
+    id: 'createPollButton',
+    vueComponent: Vue.options.components['create-poll-composer'],
+    rank: 40,
   });
   
 }

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/pollExtensions.js
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/pollExtensions.js
@@ -16,27 +16,36 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-export function initExtensions() {
-  extensionRegistry.registerExtension('ActivityComposer', 'activity-composer-action', {
-    key: 'poll',
-    rank: 40,
-    resourceBundle: 'locale.portlet.Poll',
-    labelKey: 'composer.poll.create',
-    description: 'composer.poll.create.drawer.description',
-    iconClass: 'createPollComposerIcon',
-    enabled: true,
-    component: {
-      name: 'create-poll-drawer',
-      props: {
-      },
-      model: {
-        value: [],
-        default: []
-      },
-      events: []
+const pollActivityComposerPlugin = {
+  key: 'poll',
+  rank: 40,
+  resourceBundle: 'locale.portlet.Poll',
+  labelKey: 'composer.poll.create.drawer.label',
+  description: 'composer.poll.create.drawer.description',
+  iconClass: 'createPollComposerIcon',
+  enabled: true,
+  component: {
+    name: 'create-poll-drawer',
+    props: {
     },
-    onExecute: (createPollDrawerComponent) => {
-      createPollDrawerComponent.openDrawer();
-    }
+    model: {
+      value: [],
+      default: []
+    },
+    events: []
+  },
+  onExecute: (createPollDrawerComponent) => {
+    createPollDrawerComponent.openDrawer();
+  }
+};
+
+export function initExtensions() {
+  extensionRegistry.registerExtension('ActivityComposer', 'activity-composer-action', pollActivityComposerPlugin);
+
+  document.addEventListener('poll-composer-button-text',(data)=>{
+    pollActivityComposerPlugin.labelKey = data.detail.labelKey;
+    pollActivityComposerPlugin.description = data.detail.description;
+  
   });
+  
 }

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/pollExtensions.js
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/pollExtensions.js
@@ -21,7 +21,7 @@ export function initExtensions() {
   extensionRegistry.registerComponent('ActivityComposerFooterAction', 'activity-composer-footer-action', {
     id: 'createPollButton',
     vueComponent: Vue.options.components['create-poll-composer'],
-    rank: 40,
+    rank: 20,
   });
   
 }


### PR DESCRIPTION
After this change, we will be able to edit the created poll before posting it as long as the create poll drawer is not closed and the page is not refreshed. The label "you have created a poll" will be displayed in the main activity composer instead of "create a poll" label and the post button will be enabled even if no activity message is filled.