### PR TITLE
Task-55687: Resume poll feature flag

### DIFF
--- a/poll-webapp/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/poll-webapp/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -3,5 +3,6 @@
   xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
    
   <import>war:/conf/poll/dynamic-container-configuration.xml</import>
+  <import>war:/conf/poll/poll-configuration.xml</import>
 
 </configuration>

--- a/poll-webapp/src/main/webapp/WEB-INF/conf/poll/poll-configuration.xml
+++ b/poll-webapp/src/main/webapp/WEB-INF/conf/poll/poll-configuration.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
+        xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+
+  <component>
+    <key>PollFeatureProperties</key>
+    <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
+    <init-params>
+      <properties-param>
+        <name>PollFeatureProperties</name>
+        <description>Poll Feature enablement flag</description>
+        <property name="exo.feature.poll.enabled" value="${exo.feature.poll.enabled:false}" />
+      </properties-param>
+    </init-params>
+  </component>
+</configuration>

--- a/poll-webapp/src/main/webapp/WEB-INF/jsp/pollExtensions.jsp
+++ b/poll-webapp/src/main/webapp/WEB-INF/jsp/pollExtensions.jsp
@@ -1,0 +1,20 @@
+<%@ page import="org.exoplatform.commons.utils.CommonsUtils"%>
+<%@page import="org.exoplatform.services.security.ConversationState"%>
+<%@page import="org.exoplatform.services.security.Identity"%>
+
+<%
+boolean pollFeatureEnabled = CommonsUtils.isFeatureActive("poll");
+if (ConversationState.getCurrent() != null) {
+  Identity currentIdentity = ConversationState.getCurrent().getIdentity();
+  if (currentIdentity != null) {
+    pollFeatureEnabled = CommonsUtils.isFeatureActive("poll", currentIdentity.getUserId());    	
+  }
+}
+%>
+
+<script type="text/javascript">
+  var pollFeatureEnabled = <%=pollFeatureEnabled%>
+  if (pollFeatureEnabled) {
+    require(['PORTLET/poll/PollExtensions'], app => app.init());
+  }
+</script>

--- a/poll-webapp/src/main/webapp/WEB-INF/jsp/pollExtensions.jsp
+++ b/poll-webapp/src/main/webapp/WEB-INF/jsp/pollExtensions.jsp
@@ -10,11 +10,9 @@ if (ConversationState.getCurrent() != null) {
     pollFeatureEnabled = CommonsUtils.isFeatureActive("poll", currentIdentity.getUserId());    	
   }
 }
+String enabledSpaces = System.getProperty("exo.feature.poll.enabledSpaces", "");
 %>
 
 <script type="text/javascript">
-  var pollFeatureEnabled = <%=pollFeatureEnabled%>
-  if (pollFeatureEnabled) {
-    require(['PORTLET/poll/PollExtensions'], app => app.init());
-  }
+  require(['PORTLET/poll/PollExtensions'], app => app.init(<%=pollFeatureEnabled%>, '<%=enabledSpaces%>'));
 </script>

--- a/poll-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/poll-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -10,7 +10,7 @@
     <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
-      <value>/html/pollExtensions.html</value>
+      <value>/WEB-INF/jsp/pollExtensions.jsp</value>
     </init-param>
     <expiration-cache>-1</expiration-cache>
     <cache-scope>PUBLIC</cache-scope>

--- a/poll-webapp/src/main/webapp/html/pollExtensions.html
+++ b/poll-webapp/src/main/webapp/html/pollExtensions.html
@@ -1,3 +1,0 @@
-<script type="text/javascript">
-  require(['PORTLET/poll/PollExtensions'], app => app.init());
-</script>

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/main.js
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/main.js
@@ -40,6 +40,6 @@ if (!Vue.prototype.$pollService) {
   });
 }
 
-export function init() {
-  initExtensions();
+export function init(pollFeatureEnabled, enabledSpaces) {
+  initExtensions(pollFeatureEnabled, enabledSpaces);
 }

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/pollExtensions.js
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/pollExtensions.js
@@ -18,7 +18,7 @@
  */
 
 export function initExtensions(pollFeatureEnabled, enabledSpaces) {
-  if (pollFeatureEnabled && eXo.env.portal.spaceName && eXo.env.portal.spaceName !== '' && (enabledSpaces === '' || enabledSpaces.includes(eXo.env.portal.spaceName))) {
+  if (pollFeatureEnabled && eXo.env.portal.spaceGroup && eXo.env.portal.spaceGroup !== '' && (enabledSpaces === '' || enabledSpaces.includes(eXo.env.portal.spaceGroup))) {
     extensionRegistry.registerComponent('ActivityComposerFooterAction', 'activity-composer-footer-action', {
       id: 'createPollButton',
       vueComponent: Vue.options.components['create-poll-composer'],

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/pollExtensions.js
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/pollExtensions.js
@@ -17,8 +17,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-export function initExtensions() {
-  if (eXo.env.portal.spaceId && eXo.env.portal.spaceId !== '') {
+export function initExtensions(pollFeatureEnabled, enabledSpaces) {
+  if (pollFeatureEnabled && eXo.env.portal.spaceName && eXo.env.portal.spaceName !== '' && (enabledSpaces === '' || enabledSpaces.includes(eXo.env.portal.spaceName))) {
     extensionRegistry.registerComponent('ActivityComposerFooterAction', 'activity-composer-footer-action', {
       id: 'createPollButton',
       vueComponent: Vue.options.components['create-poll-composer'],


### PR DESCRIPTION
Prior to this change, poll feature is always enabled. After this commit we have added 3 properties:
- exo.feature.poll.enabled=true (false by default means that poll feature is disabled, true if we want to enable poll feature)
- exo.feature.poll.permissions=/platform/xxxx,/platform/yyy : Specify for which groups the create poll space composer button will be accessible. The group member is allowed to create a space poll only when he is already authorized to access to the space composer. 
- exo.feature.poll.enabledSpaces=poll1,poll2,poll3 : Specify for which spaces the create poll button will be accessible from the space composer. The space group name should be specified.

Enabling or disabling poll feature concerns only create poll button, the poll activities still accessible in the both cases.