### PR TITLE
Task-56066: Fix displaying empty poll options

### DIFF
--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollComposer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/CreatePollComposer.vue
@@ -104,7 +104,7 @@ export default {
     postPoll(message) {
       const poll = {
         question: this.savedPoll.question,
-        options: this.savedPoll.options.filter(option => option.data != null)
+        options: this.savedPoll.options.filter(option => option.data != null && option.data !== '')
           .map(option => {
             return {
               description: option.data,


### PR DESCRIPTION
Prior to this fix, when creating a poll, filling an optional option field then emptying it, an option with an empty value is added with the poll . After this commit, we will prevent creating empty options. 