### PR TITLE
Task-56747: Prevent super user or super admins not space members to vote on created polls and allow other space members to vote

### DIFF
--- a/poll-webapp/src/main/webapp/skin/less/poll.less
+++ b/poll-webapp/src/main/webapp/skin/less/poll.less
@@ -133,6 +133,10 @@
           height: 85%;
           margin: 2px 2px;
         }
+        .poll-creator-non-member {
+          opacity: 0.68;
+          cursor: pointer;
+        }
       }
     }
     .total-votes {

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/PollActivity.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/PollActivity.vue
@@ -32,7 +32,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 :value="answer.percent"
                 color="transparent"
                 height="20"
-                :class="{ 'answer-voted': true, selected: answer.voted }"
+                :class="{ 'answer-cant-vote': !isSpaceMember, 'answer-voted': true, selected: answer.voted }"
                 @click.prevent="handleVote(answer)"
                 rounded>
                 <template>
@@ -79,7 +79,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 </template>
               </v-progress-linear>
             </div>
-            <span class="voteBackground voteBackgroundPollCreator" :style="{ width: (!visibleResults && isPollCreator) || visibleResults ? fixWidth(answer.percent) : '0%' }"></span>
+            <span :class="`voteBackground voteBackgroundPollCreator  ${!isSpaceMember && 'poll-creator-non-member'}`"
+                  :title="!isSpaceMember && $t('activity.poll.not.space.member')"
+                  :style="{ width: (!visibleResults && isPollCreator) || visibleResults ? fixWidth(answer.percent) : '0%'}"></span>
           </template>
 
           <template v-else>


### PR DESCRIPTION
Prior to this change, super user and super space admins not members of the space can't vote on their created polls but without fade effect and informative message. In addition to that, other space members can't vote on these created polls.
After this fix, these super user and super space admins not members of the space should have fade effect and informative message indicating no possibility to vote their created polls. Other space members should be able to vote on these created polls.