### PR TITLE
Task-57292: Fix votes label used to display number of votes

### DIFF
--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/PollActivity.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/PollActivity.vue
@@ -168,7 +168,7 @@ export default {
       return totalVotes;
     },
     totalVotesFormatted(){
-      return this.totalVotes === 1 ? this.$t('activity.poll.many.votes.label',{0: this.totalVotes}) : this.$t('activity.poll.single.vote.label',{0: this.totalVotes});
+      return this.totalVotes === 1 ? this.$t('activity.poll.single.vote.label',{0: this.totalVotes}) : this.$t('activity.poll.many.votes.label',{0: this.totalVotes});
     },
     mostVotes() {
       let max = 0;


### PR DESCRIPTION
Before this change, the votes labels used to display the number of votes is wrong. After this fix, the votes label is fixed according the the number of votes.