### PR TITLE
Task-58893 : Make the poll result more readable When the poll is finished

### DIFF
--- a/poll-webapp/src/main/webapp/skin/less/poll.less
+++ b/poll-webapp/src/main/webapp/skin/less/poll.less
@@ -95,6 +95,11 @@
           position: relative;
           z-index: 1;
         }
+        .vote-content-winning{
+          position: relative;
+          z-index: 1;
+          font-weight: bold;
+        }
         .vote-percent {
           font-weight: bold;
           min-width: 51px;
@@ -123,14 +128,14 @@
           left: 0;
           bottom: 0;
           z-index: 0;
-          background-color: @greyColor;
+          background-color: @greyColorDefault;
           border-top-left-radius: 5px;
           border-bottom-left-radius: 5px;
           transition: all .3s cubic-bezier(0.5,1.2,.5,1.2);
           -webkit-transition: all .3s cubic-bezier(0.5,1.2,.5,1.2);
           -moz-transition: all .3s cubic-bezier(0.5,1.2,.5,1.2);
           &.selected {
-            background-color: @primaryColor;
+            background-color: #C7D2E1;
           }
         }
         .voteBackgroundPollCreator {

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/PollActivity.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/PollActivity.vue
@@ -100,7 +100,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     class="vote-percent"
                     v-text="answer.percent"></span>
                   <span
-                    :class="mostVotes === answer.votes ?  'vote-content-winning':'vote-content text-truncate' "
+                    :class="mostVotes === answer.votes ?  'vote-content-winning text-truncate':'vote-content text-truncate' "
                     :title="answer.description"
                     v-sanitized-html="answer.description"></span>
                 </div>

--- a/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/PollActivity.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-extensions/components/PollActivity.vue
@@ -100,7 +100,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     class="vote-percent"
                     v-text="answer.percent"></span>
                   <span
-                    class="vote-content text-truncate"
+                    :class="mostVotes === answer.votes ?  'vote-content-winning':'vote-content text-truncate' "
                     :title="answer.description"
                     v-sanitized-html="answer.description"></span>
                 </div>


### PR DESCRIPTION
Prior this change when the poll is finished, the answer is displayed in a box with a primary color in background.
Make the poll result more readable by using the light blue color for the background and the text in bold.
(Cherry-picked from [PR](https://github.com/Meeds-io/poll/pull/46) && [PR](https://github.com/Meeds-io/poll/pull/45))