### PR TITLE
fix: user should not be able to vote twice in a poll - EXO-60901 (#58)

### DIFF
--- a/poll-api/src/main/java/io/meeds/poll/service/PollService.java
+++ b/poll-api/src/main/java/io/meeds/poll/service/PollService.java
@@ -123,4 +123,12 @@ public interface PollService {
    * @throws IllegalAccessException when the current user is not authorized to get {@link poll} total votes
    */
   int getPollTotalVotes(long pollId, Identity currentIdentity) throws IllegalAccessException;
+
+  /**
+   * Checks if the user voted in the poll
+   * @param currentIdentity User identifier representing The Voter
+   * @param pollId technical identifier of the poll
+   * @return boolean true if the user did already vote this Poll
+   */
+  boolean didVote(Identity currentIdentity, Long pollId);
 }

--- a/poll-services/src/main/java/io/meeds/poll/dao/PollVoteDAO.java
+++ b/poll-services/src/main/java/io/meeds/poll/dao/PollVoteDAO.java
@@ -49,4 +49,11 @@ public class PollVoteDAO extends GenericDAOJPAImpl<PollVoteEntity, Long> {
       return 0;
     }
   }
+
+  public long countUserVotesInPoll(Long pollId, long userId) {
+    TypedQuery<Long> query = getEntityManager().createNamedQuery("PollVote.countUserVotesInPoll", Long.class);
+    query.setParameter("pollId", pollId);
+    query.setParameter("userId", userId);
+    return query.getSingleResult();
+  }
 }

--- a/poll-services/src/main/java/io/meeds/poll/entity/PollVoteEntity.java
+++ b/poll-services/src/main/java/io/meeds/poll/entity/PollVoteEntity.java
@@ -33,6 +33,9 @@ import java.util.Date;
 @NamedQuery(name = "PollVote.countPollTotalVotes",
 query = "SELECT COUNT(*) FROM PollVote pollVote, PollOption pollOption, Poll poll " +
         "where pollVote.pollOptionId = pollOption.id AND pollOption.pollId = poll.id AND poll.id = :pollId ")
+@NamedQuery(name = "PollVote.countUserVotesInPoll", query = "select count(*) from PollVote pollVote "
+    + "inner join PollOption pollOption on pollVote.pollOptionId = pollOption.id "
+    + "inner join Poll poll on pollOption.pollId = poll.id where poll.id = :pollId and pollVote.voterId = :userId")
 
 public class PollVoteEntity implements Serializable {
 

--- a/poll-services/src/main/java/io/meeds/poll/rest/PollRest.java
+++ b/poll-services/src/main/java/io/meeds/poll/rest/PollRest.java
@@ -150,6 +150,9 @@ public class PollRest implements ResourceContainer {
       if (poll == null) {
         return Response.status(Response.Status.NOT_FOUND).build();
       }
+      if(pollService.didVote(currentIdentity, pollOption.getPollId())) {
+        return Response.status(Response.Status.FORBIDDEN).entity("User did already vote an option in this poll").build();
+      }
       PollVote pollVote = pollService.vote(optionId, String.valueOf(poll.getSpaceId()), currentIdentity);
       return Response.ok(pollVote).build();
     } catch (IllegalAccessException e) {

--- a/poll-services/src/main/java/io/meeds/poll/service/PollServiceImpl.java
+++ b/poll-services/src/main/java/io/meeds/poll/service/PollServiceImpl.java
@@ -211,7 +211,13 @@ public class PollServiceImpl implements PollService {
     }
     return pollStorage.countPollTotalVotes(pollId);
   }
-  
+
+  @Override
+  public boolean didVote(org.exoplatform.services.security.Identity currentIdentity, Long pollId) {
+    long currentUserIdentityId = PollUtils.getCurrentUserIdentityId(identityManager, currentIdentity.getUserId());
+    return pollStorage.didVote(currentUserIdentityId, pollId);
+  }
+
   private Poll postPollActivity(String message,
                                 String spaceId,
                                 org.exoplatform.services.security.Identity currentIdentity,

--- a/poll-services/src/main/java/io/meeds/poll/storage/PollStorage.java
+++ b/poll-services/src/main/java/io/meeds/poll/storage/PollStorage.java
@@ -97,4 +97,8 @@ public class PollStorage {
   public int countPollTotalVotes(long pollId) {
     return pollVoteDAO.countPollTotalVotes(pollId);
   }
+
+  public boolean didVote(long currentUserIdentityId, Long pollId) {
+    return pollVoteDAO.countUserVotesInPoll(pollId, currentUserIdentityId) > 0;
+  }
 }

--- a/poll-services/src/test/java/io/meeds/poll/dao/PollVoteDAOTest.java
+++ b/poll-services/src/test/java/io/meeds/poll/dao/PollVoteDAOTest.java
@@ -129,6 +129,14 @@ public class PollVoteDAOTest extends TestCase {
     assertEquals(2, pollTotalVotes);
   }
 
+  public void testCountUserVotesInPollOptions() {
+    PollEntity createdPollEntity = createPollEntity();
+    PollOptionEntity pollOption1Entity = createPollOptionEntity(createdPollEntity.getId());
+    PollVoteEntity pollVote1Entity = createPollVoteEntity(pollOption1Entity.getId());
+    pollVoteDAO.create(pollVote1Entity);
+    assertEquals(1, pollVoteDAO.countUserVotesInPoll(createdPollEntity.getId(), creatorId));
+  }
+
   protected PollEntity createPollEntity() {
     PollEntity pollEntity = new PollEntity();
     pollEntity.setQuestion(question);

--- a/poll-services/src/test/java/io/meeds/poll/service/PollServiceTest.java
+++ b/poll-services/src/test/java/io/meeds/poll/service/PollServiceTest.java
@@ -406,4 +406,44 @@ public class PollServiceTest extends BasePollTest {
     // Then
     assertEquals(3, pollTotalVotes);
   }
+
+  @Test
+  public void testDidVote() throws IllegalAccessException {
+    // Given
+    org.exoplatform.services.security.Identity testUser1Identity = new org.exoplatform.services.security.Identity("testuser1");
+    Poll poll = new Poll();
+    poll.setQuestion("q1");
+    poll.setCreatedDate(createdDate);
+    poll.setEndDate(endDate);
+    poll.setCreatorId(Long.parseLong(user1Identity.getId()));
+    poll.setSpaceId(1L);
+    PollOption pollOption1 = new PollOption();
+    pollOption1.setDescription("pollOption");
+    PollOption pollOption2 = new PollOption();
+    pollOption2.setDescription("pollOption");
+    PollOption pollOption3 = new PollOption();
+    pollOption3.setDescription("pollOption");
+    PollOption pollOption4 = new PollOption();
+    pollOption4.setDescription("pollOption");
+    List<PollOption> pollOptionList = new ArrayList<>();
+    pollOptionList.add(pollOption1);
+    pollOptionList.add(pollOption2);
+    pollOptionList.add(pollOption3);
+    pollOptionList.add(pollOption4);
+    Poll createdPoll = pollService.createPoll(poll, pollOptionList, space.getId(), MESSAGE, testUser1Identity, new ArrayList<>());
+    List<PollOption> createdPollOptions = pollService.getPollOptionsByPollId(createdPoll.getId(), testUser1Identity);
+    // When
+    boolean didVote = pollService.didVote(testUser1Identity, createdPoll.getId());
+
+    // Then
+    assertFalse(didVote);
+
+
+    pollService.vote(String.valueOf(createdPollOptions.get(0).getId()), space.getId(), testUser1Identity);
+    // When
+    didVote = pollService.didVote(testUser1Identity, createdPoll.getId());
+
+    // Then
+    assertTrue(didVote);
+  }
 }

--- a/poll-services/src/test/java/io/meeds/poll/storage/PollStorageTest.java
+++ b/poll-services/src/test/java/io/meeds/poll/storage/PollStorageTest.java
@@ -18,8 +18,7 @@
  */
 package io.meeds.poll.storage;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -249,6 +248,21 @@ public class PollStorageTest {
 
     // Then
     assertEquals(1, pollTotalVotes);
+  }
+
+  @PrepareForTest({ EntityMapper.class })
+  @Test
+  public void testDidVote() throws Exception { // NOSONAR
+    // Given
+    Poll poll = createPoll();
+    createPollOption(poll);
+    when(pollVoteDAO.countUserVotesInPoll(poll.getId(), 1L)).thenReturn(1L);
+
+    // When
+    boolean didVote = pollStorage.didVote(1L, poll.getId());
+
+    // Then
+    assertTrue(didVote);
   }
 
   protected Poll createPoll() {


### PR DESCRIPTION
Before this fix it was possible to add new votes on a poll using a curl/fetch command. There was no restriction on the backend services that presents users from voting twice on a single poll. This fix ensutres to have one vote per user for each poll and sends a 403 HTTP error if a direct CURL/FETCH is sent. It provides API to count user votes on each poll.

(cherry picked from commit b5cab19db997f42ed1fa8882dcdba3a52b67567f)