### PR TITLE
feat: Use Spring integration PoC  - Meeds-io/MIPs#57

### DIFF
--- a/poll-packaging/pom.xml
+++ b/poll-packaging/pom.xml
@@ -12,18 +12,31 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>poll-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>poll-services</artifactId>
-      <scope>provided</scope>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>poll-webapp</artifactId>
-      <scope>provided</scope>
+      <scope>runtime</scope>
       <type>war</type>
     </dependency>
   </dependencies>
@@ -33,6 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>package-extension</id>

--- a/poll-packaging/src/main/assemblies/assembly.xml
+++ b/poll-packaging/src/main/assemblies/assembly.xml
@@ -13,7 +13,7 @@
       <includes>
         <include>${project.groupId}:poll-webapp:war</include>
       </includes>
-      <scope>provided</scope>
+      <scope>runtime</scope>
       <outputFileNameMapping>${artifact.build.finalName}.${artifact.extension}</outputFileNameMapping>
     </dependencySet>
     <!-- Libraries -->
@@ -21,9 +21,33 @@
       <useProjectArtifact>false</useProjectArtifact>
       <outputDirectory>/</outputDirectory>
       <includes>
-        <include>${project.groupId}:*:jar</include>
+        <include>*:*:jar</include>
       </includes>
-      <scope>provided</scope>
+      <excludes>
+        <!-- Prepackage libraries in Meeds -->
+        <exclude>org.ow2.asm:asm:jar</exclude>
+        <exclude>commons-codec:commons-codec:jar</exclude>
+        <exclude>commons-io:commons-io:jar</exclude>
+        <exclude>com.google.code.findbugs:jsr305:jar</exclude>
+        <exclude>org.apache.commons:commons-lang3:jar</exclude>
+        <exclude>org.apache.httpcomponents:httpcore:jar</exclude>
+        <exclude>org.apache.httpcomponents:httpclient:jar</exclude>
+        <exclude>com.fasterxml.jackson.core:jackson-annotations:jar</exclude>
+        <exclude>com.fasterxml.jackson.core:jackson-core:jar</exclude>
+        <exclude>com.fasterxml.jackson.core:jackson-databind:jar</exclude>
+        <exclude>com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar</exclude>
+        <exclude>jakarta.annotation:jakarta.annotation-api:jar</exclude>
+        <exclude>org.jetbrains.kotlin:kotlin-stdlib:jar</exclude>
+        <exclude>org.jetbrains.kotlin:kotlin-stdlib-common:jar</exclude>
+        <exclude>org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar</exclude>
+        <exclude>org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar</exclude>
+        <exclude>com.squareup.okhttp3:logging-interceptor:jar</exclude>
+        <exclude>com.squareup.okhttp3:okhttp:jar</exclude>
+        <exclude>org.reactivestreams:reactive-streams:jar</exclude>
+        <exclude>io.reactivex.rxjava2:rxjava:jar</exclude>
+        <exclude>org.yaml:snakeyaml:jar</exclude>
+      </excludes>
+      <scope>runtime</scope>
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
     </dependencySet>
   </dependencySets>

--- a/poll-services/pom.xml
+++ b/poll-services/pom.xml
@@ -16,6 +16,20 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>poll-api</artifactId>
       <scope>provided</scope>
@@ -52,6 +66,8 @@
         <groupId>io.openapitools.swagger</groupId>
         <artifactId>swagger-maven-plugin</artifactId>
         <configuration>
+          <!-- Should be changed, using https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api -->
+          <skip>true</skip>
           <useResourcePackagesChildren>true</useResourcePackagesChildren>
           <resourcePackages>
             <locations>io.meeds.poll.rest</locations>

--- a/poll-services/src/main/java/io/meeds/poll/activity/processor/PollActivityProcessor.java
+++ b/poll-services/src/main/java/io/meeds/poll/activity/processor/PollActivityProcessor.java
@@ -22,13 +22,22 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
 import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.social.core.BaseActivityProcessorPlugin;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.manager.ActivityManager;
 
 import io.meeds.poll.model.Poll;
 import io.meeds.poll.model.PollOption;
@@ -38,15 +47,34 @@ import io.meeds.poll.service.PollService;
 import io.meeds.poll.utils.PollUtils;
 import io.meeds.poll.utils.RestEntityBuilder;
 
+@Component
 public class PollActivityProcessor extends BaseActivityProcessorPlugin {
 
-  private PollService      pollService;
+  private static final Log    LOG                     = ExoLogger.getLogger(PollActivityProcessor.class);
 
-  private static final Log LOG = ExoLogger.getLogger(PollActivityProcessor.class);
+  private static final String ACTIVITY_PROCESSOR_NAME = "PollActivityProcessor";
 
-  public PollActivityProcessor(PollService pollService, InitParams initParams) {
-    super(initParams);
-    this.pollService = pollService;
+  @Value("${meeds.poll.activity.processor.priority:0}")
+  private static int          processorPriority;
+
+  @Autowired
+  private PollService         pollService;
+
+  @Autowired
+  private ActivityManager     activityManager;
+
+  public PollActivityProcessor() {
+    super(getPriorityInitParam());
+  }
+
+  @PostConstruct
+  public void init() {
+    activityManager.addProcessor(this);
+  }
+
+  @Override
+  public String getName() {
+    return ACTIVITY_PROCESSOR_NAME;
   }
 
   @Override
@@ -90,4 +118,25 @@ public class PollActivityProcessor extends BaseActivityProcessorPlugin {
       activity.getLinkedProcessedEntities().put(PollUtils.POLL_ACTIVITY_TYPE, pollRestEntity);
     }
   }
+
+  private static InitParams getPriorityInitParam() {
+    return new InitParams() {
+      private static final long serialVersionUID = 6692556831691417605L;
+
+      @Override
+      public ValueParam getValueParam(String name) {
+        if (StringUtils.equals("priority", name)) {
+          return new ValueParam() {
+            @Override
+            public String getValue() {
+              return String.valueOf(processorPriority);
+            }
+          };
+        } else {
+          return super.getValueParam(name);
+        }
+      }
+    };
+  }
+
 }

--- a/poll-services/src/main/java/io/meeds/poll/dao/PollOptionDAO.java
+++ b/poll-services/src/main/java/io/meeds/poll/dao/PollOptionDAO.java
@@ -18,18 +18,20 @@
  */
 package io.meeds.poll.dao;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
+
+import org.springframework.stereotype.Component;
 
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 
 import io.meeds.poll.entity.PollOptionEntity;
 import io.meeds.poll.utils.PollUtils;
 
-import java.util.Collections;
-
+@Component
 public class PollOptionDAO extends GenericDAOJPAImpl<PollOptionEntity, Long> {
 
   public List<PollOptionEntity> findPollOptionsByPollId(Long pollId) {

--- a/poll-services/src/main/java/io/meeds/poll/dao/PollVoteDAO.java
+++ b/poll-services/src/main/java/io/meeds/poll/dao/PollVoteDAO.java
@@ -21,10 +21,13 @@ package io.meeds.poll.dao;
 import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
 
+import org.springframework.stereotype.Component;
+
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 
 import io.meeds.poll.entity.PollVoteEntity;
 
+@Component
 public class PollVoteDAO extends GenericDAOJPAImpl<PollVoteEntity, Long> {
 
   public int countPollOptionTotalVotes(long pollOptionId) {

--- a/poll-services/src/main/java/io/meeds/poll/listener/AnalyticsPollListener.java
+++ b/poll-services/src/main/java/io/meeds/poll/listener/AnalyticsPollListener.java
@@ -33,14 +33,18 @@ import static io.meeds.poll.utils.PollUtils.getPollDuration;
 import java.util.Arrays;
 import java.util.HashSet;
 
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
 import org.exoplatform.analytics.model.StatisticData;
 import org.exoplatform.analytics.utils.AnalyticsUtils;
-import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.services.listener.Asynchronous;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.social.core.identity.model.Identity;
-import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
@@ -49,15 +53,31 @@ import io.meeds.poll.model.Poll;
 import io.meeds.poll.service.PollService;
 
 @Asynchronous
+@Component
 public class AnalyticsPollListener extends Listener<String, Poll> {
 
-  private static final String POLL_ID                    = "PollId";
+  private static final String   POLL_ID         = "PollId";
 
-  private IdentityManager     identityManager;
+  private static final String[] LISTENER_EVENTS = { "meeds.poll.createPoll", "meeds.poll.votePoll" };
 
-  private SpaceService        spaceService;
+  @Autowired
+  private IdentityManager       identityManager;
 
-  private PollService         pollService;
+  @Autowired
+  private SpaceService          spaceService;
+
+  @Autowired
+  private PollService           pollService;
+
+  @Autowired
+  private ListenerService       listenerService;
+
+  @PostConstruct
+  public void init() {
+    for (String eventName : LISTENER_EVENTS) {
+      listenerService.addListener(eventName, this);
+    }
+  }
 
   @Override
   public void onEvent(Event<String, Poll> event) throws Exception {
@@ -70,47 +90,30 @@ public class AnalyticsPollListener extends Listener<String, Poll> {
     }
     String userName = event.getSource();
     long userId = 0;
-    Identity identity = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, userName);
+    Identity identity = identityManager.getOrCreateUserIdentity(userName);
     if (identity != null) {
       userId = Long.parseLong(identity.getId());
     }
     StatisticData statisticData = new StatisticData();
-    Space space = getSpaceService().getSpaceById(String.valueOf(poll.getSpaceId()));
+    Space space = spaceService.getSpaceById(String.valueOf(poll.getSpaceId()));
     statisticData.setModule(POLL_MODULE);
     statisticData.setSubModule(POLL_MODULE);
     statisticData.setOperation(operation);
     statisticData.setUserId(userId);
     statisticData.addParameter(POLL_ID, poll.getId());
     statisticData.addParameter(POLL_ACTIVITY_ID, poll.getActivityId());
-    statisticData.addParameter(POLL_OPTIONS_NUMBER, getPollService().getPollOptionsNumber(poll.getId(), new org.exoplatform.services.security.Identity(userName)));
+    statisticData.addParameter(POLL_OPTIONS_NUMBER,
+                               pollService.getPollOptionsNumber(poll.getId(),
+                                                                new org.exoplatform.services.security.Identity(userName)));
     statisticData.addParameter(POLL_DURATION, getPollDuration(poll));
-    statisticData.addParameter(POLL_TOTAL_VOTES, getPollService().getPollTotalVotes(poll.getId(), new org.exoplatform.services.security.Identity(userName)));
+    statisticData.addParameter(POLL_TOTAL_VOTES,
+                               pollService.getPollTotalVotes(poll.getId(),
+                                                             new org.exoplatform.services.security.Identity(userName)));
     statisticData.addParameter(POLL_SPACE_MEMBERS_COUNT, getSize(space.getMembers()));
 
     AnalyticsUtils.addStatisticData(statisticData);
   }
 
-  public IdentityManager getIdentityManager() {
-    if (identityManager == null) {
-      identityManager = ExoContainerContext.getService(IdentityManager.class);
-    }
-    return identityManager;
-  }
-
-  public SpaceService getSpaceService() {
-    if (spaceService == null) {
-      spaceService = ExoContainerContext.getService(SpaceService.class);
-    }
-    return spaceService;
-  }
-
-  public PollService getPollService() {
-    if (pollService == null) {
-      pollService = ExoContainerContext.getService(PollService.class);
-    }
-    return pollService;
-  }
-  
   private static int getSize(String[] array) {
     return array == null ? 0 : new HashSet<>(Arrays.asList(array)).size();
   }

--- a/poll-services/src/main/java/io/meeds/poll/listener/GamificationPollListener.java
+++ b/poll-services/src/main/java/io/meeds/poll/listener/GamificationPollListener.java
@@ -36,6 +36,10 @@ import static io.meeds.poll.utils.PollUtils.VOTE_POLL_OPERATION_NAME;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.PostConstruct;
+
+import org.springframework.stereotype.Component;
+
 import org.exoplatform.services.listener.Asynchronous;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
@@ -49,18 +53,27 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import io.meeds.poll.model.Poll;
 
 @Asynchronous
+@Component
 public class GamificationPollListener extends Listener<String, Poll> {
 
-  private static final Log LOG = ExoLogger.getLogger(GamificationPollListener.class);
+  private static final Log      LOG             = ExoLogger.getLogger(GamificationPollListener.class);
 
-  private IdentityManager  identityManager;
+  private static final String[] LISTENER_EVENTS = { "meeds.poll.createPoll", "meeds.poll.votePoll" };
 
-  private ListenerService  listenerService;
+  private IdentityManager       identityManager;
 
-  public GamificationPollListener(IdentityManager identityManager,
-                                  ListenerService listenerService) {
+  private ListenerService       listenerService;
+
+  public GamificationPollListener(IdentityManager identityManager, ListenerService listenerService) {
     this.identityManager = identityManager;
     this.listenerService = listenerService;
+  }
+
+  @PostConstruct
+  public void init() {
+    for (String eventName : LISTENER_EVENTS) {
+      listenerService.addListener(eventName, this);
+    }
   }
 
   @Override

--- a/poll-services/src/main/java/io/meeds/poll/service/PollServiceImpl.java
+++ b/poll-services/src/main/java/io/meeds/poll/service/PollServiceImpl.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
 
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.social.core.activity.model.ActivityFile;
@@ -43,6 +45,8 @@ import io.meeds.poll.model.PollVote;
 import io.meeds.poll.storage.PollStorage;
 import io.meeds.poll.utils.PollUtils;
 
+@Primary
+@Component
 public class PollServiceImpl implements PollService {
 
   private PollStorage     pollStorage;
@@ -55,7 +59,6 @@ public class PollServiceImpl implements PollService {
   
   private UserACL userACL;
 
-
   public PollServiceImpl(PollStorage pollStorage, SpaceService spaceService, IdentityManager identityManager, ActivityManager activityManager, UserACL userACL) {
     this.pollStorage = pollStorage;
     this.spaceService = spaceService;
@@ -64,9 +67,6 @@ public class PollServiceImpl implements PollService {
     this.userACL = userACL;
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public Poll createPoll(Poll poll,
                          List<PollOption> pollOptions,

--- a/poll-services/src/main/java/io/meeds/poll/storage/PollStorage.java
+++ b/poll-services/src/main/java/io/meeds/poll/storage/PollStorage.java
@@ -21,6 +21,8 @@ package io.meeds.poll.storage;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.stereotype.Service;
+
 import io.meeds.poll.dao.PollDAO;
 import io.meeds.poll.dao.PollOptionDAO;
 import io.meeds.poll.dao.PollVoteDAO;
@@ -32,7 +34,9 @@ import io.meeds.poll.model.PollOption;
 import io.meeds.poll.model.PollVote;
 import io.meeds.poll.utils.EntityMapper;
 
+@Service
 public class PollStorage {
+
   private PollDAO       pollDAO;
 
   private PollOptionDAO pollOptionDAO;
@@ -62,7 +66,7 @@ public class PollStorage {
 
   public List<PollOption> getPollOptionsByPollId(long pollId) {
     List<PollOptionEntity> pollOptionEntities = pollOptionDAO.findPollOptionsByPollId(pollId);
-    return pollOptionEntities.stream().map(EntityMapper::fromPollOptionEntity).collect(Collectors.toList());
+    return pollOptionEntities.stream().map(EntityMapper::fromPollOptionEntity).toList();
   }
 
   public Poll updatePoll(Poll poll) {

--- a/poll-services/src/main/java/io/meeds/spring/integration/kernel/PortalApplicationContext.java
+++ b/poll-services/src/main/java/io/meeds/spring/integration/kernel/PortalApplicationContext.java
@@ -1,0 +1,249 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.spring.integration.kernel;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import javax.servlet.ServletContext;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.RootContainer.PortalContainerPostInitTask;
+import org.exoplatform.container.spi.ComponentAdapter;
+
+/**
+ * A class to let Spring context initialized once the
+ * {@link PortalContainer}finishes startup to bring all defined Kernel Services
+ * into Spring Context in order to be able to use annotations to inject Kernel
+ * services
+ */
+public class PortalApplicationContext extends AnnotationConfigServletWebServerApplicationContext {
+
+  private static final Logger                      LOG               = LoggerFactory.getLogger(PortalApplicationContext.class);
+
+  private static final Set<String>                 KERNEL_BEAN_NAMES = new HashSet<>();
+
+  private static final Map<String, String>         BEAN_NAMES        = new HashMap<>();
+
+  private static final Map<String, BeanDefinition> BEAN_DEFINITIONS  = new HashMap<>();
+
+  private ServletContext                           servletContext;
+
+  public PortalApplicationContext(ServletContext servletContext, DefaultListableBeanFactory beanFactory) {
+    super(beanFactory);
+    this.servletContext = servletContext;
+  }
+
+  @Override
+  protected void finishBeanFactoryInitialization(ConfigurableListableBeanFactory beanFactory) {
+    PortalContainer.addInitTask(servletContext, new PortalContainerPostInitTask() {
+      @Override
+      public void execute(ServletContext context, PortalContainer portalContainer) {
+        // Register beans in Spring
+        BeanDefinitionRegistry beanRegistry = (BeanDefinitionRegistry) beanFactory;
+        registerKernelComponentsAsBeans(beanRegistry, portalContainer);
+        registerSharedBeans(beanRegistry);
+        // Continue startup of Spring
+        initSpringContext(beanFactory);
+        // Register Spring Beans in Kernel Container
+        registerBeansInKernelContainer(portalContainer);
+      }
+
+    }, "portal");
+  }
+
+  @Override
+  protected void finishRefresh() {
+    // Override to not be invoked in Context startup time
+  }
+
+  private void initSpringContext(ConfigurableListableBeanFactory beanFactory) {
+    long start = System.currentTimeMillis();
+    LOG.info("Start Spring context initialization of webapp '{}'", servletContext.getServletContextName());
+    PortalApplicationContext.super.finishBeanFactoryInitialization(beanFactory);
+    PortalApplicationContext.super.finishRefresh();
+    LOG.info("Spring context '{}' initialized in {}ms",
+             servletContext.getServletContextName(),
+             System.currentTimeMillis() - start);
+  }
+
+  private void registerBeansInKernelContainer(PortalContainer portalContainer) {
+    Stream.of(getBeanDefinitionNames())
+          .filter(beanName -> portalContainer.getComponentAdapter(beanName) == null)
+          .filter(beanName -> !KERNEL_BEAN_NAMES.contains(beanName))
+          .forEach(beanName -> {
+            Object bean = getBean(beanName);
+            BeanDefinition beanDefinition = getBeanDefinition(beanName);
+            String beanClassName = beanDefinition.getBeanClassName();
+            Class<?> beanClass = getBeanClass(portalContainer, beanClassName, bean);
+            if (beanClass != null) {
+              LOG.debug("Register Spring Bean '{}' as Kernel service", beanClass.getName());
+              portalContainer.registerComponentInstance(beanClass, bean);
+              BEAN_NAMES.put(beanName, beanClass.getName());
+              BEAN_DEFINITIONS.put(beanClass.getName(), beanDefinition);
+            }
+          });
+  }
+
+  private void registerSharedBeans(BeanDefinitionRegistry beanRegistry) {
+    BEAN_NAMES.forEach((beanName, beanClassName) -> beanRegistry.registerBeanDefinition(beanName,
+                                                                                        BEAN_DEFINITIONS.get(beanClassName)));
+  }
+
+  @SuppressWarnings({
+      "unchecked", "rawtypes"
+  })
+  private List<?> registerKernelComponentsAsBeans(BeanDefinitionRegistry beanRegistry, PortalContainer portalContainer) {
+    List<Class> beanClasses = portalContainer.getComponentAdapters()
+                                             .stream()
+                                             .filter(adapter -> !BEAN_DEFINITIONS.containsKey(adapter.getComponentKey()))
+                                             .map(adapter -> this.beanNameToClass(adapter, portalContainer))
+                                             .filter(Objects::nonNull)
+                                             .distinct()
+                                             .toList();
+
+    return beanClasses.stream()
+                      // Avoid having two instances inheriting from the same API
+                      // interface to not get NoUniqueBeanDefinitionException
+                      .filter(c -> {
+                        Class ec = beanClasses.stream()
+                                              .filter(oc -> !oc.equals(c) && oc.isAssignableFrom(c))
+                                              .findFirst()
+                                              .orElse(null);
+                        if (ec != null || KERNEL_BEAN_NAMES.contains(c.getName())) {
+                          LOG.debug("Kernel Service '{}' is already defined by other Service with Key {}. Registration will be ignored.",
+                                    c.getName(),
+                                    ec.getName());
+                          return false;
+                        } else {
+                          KERNEL_BEAN_NAMES.add(c.getName());
+                          return true;
+                        }
+                      })
+                      .map(beanClassName -> registerBean(portalContainer, beanRegistry, beanClassName))
+                      .filter(Objects::nonNull)
+                      .toList();
+  }
+
+  private Class<?> registerBean(PortalContainer portalContainer, BeanDefinitionRegistry beanRegistry, Class<?> beanClass) {
+    RootBeanDefinition beanDefinition = createBeanDefinition(beanClass, portalContainer);
+    beanRegistry.registerBeanDefinition(beanClass.getName(), beanDefinition);
+    LOG.debug("Kernel service '{}' injected in Spring context", beanClass.getName());
+    return beanClass;
+  }
+
+  private <T> RootBeanDefinition createBeanDefinition(Class<T> keyClass, PortalContainer portalContainer) {
+    RootBeanDefinition beanDefinition = new RootBeanDefinition(keyClass,
+                                                               () -> {
+                                                                 T instance =
+                                                                            portalContainer.getComponentInstanceOfType(keyClass);
+                                                                 LOG.debug("Getting Kernel Service '{}' to inject in Spring context. Found = {}",
+                                                                           keyClass,
+                                                                           instance != null);
+                                                                 return instance;
+                                                               });
+    beanDefinition.setLazyInit(true);
+    beanDefinition.setDependencyCheck(AbstractBeanDefinition.DEPENDENCY_CHECK_NONE);
+    return beanDefinition;
+  }
+
+  private Class<?> getBeanClass(PortalContainer portalContainer,
+                                String beanClassName,
+                                Object bean) {
+    try {
+      if (StringUtils.isBlank(beanClassName) || bean == null) {
+        return null;
+      }
+      Class<?> beanClass = portalContainer.getPortalClassLoader().loadClass(beanClassName);
+      if (bean.getClass().isAssignableFrom(beanClass)
+          && (isBeanClassValid(beanClass) || isBeanClassValid(bean.getClass()))
+          && !isConfigurationBean(beanClass)
+          && !isConfigurationBean(bean.getClass())
+          && (isServiceBean(beanClass) || isServiceBean(bean.getClass()))) {
+        if (isServiceBean(bean.getClass())) {
+          return bean.getClass();
+        } else {
+          return beanClass;
+        }
+      } else {
+        LOG.debug("Ignore registering Spring Bean '{}/{}' as Kernel service",
+                  beanClassName,
+                  bean.getClass().getName());
+        return null;
+      }
+    } catch (ClassNotFoundException e) {
+      LOG.debug("Ignore registering Spring Bean '{}' as Kernel service since it's class is not found in shared ClassLoader",
+                beanClassName);
+      return null;
+    }
+  }
+
+  private boolean isConfigurationBean(Class<?> beanClass) {
+    return beanClass.isAnnotationPresent(Configuration.class) || beanClass.isAnnotationPresent(SpringBootApplication.class);
+  }
+
+  private boolean isBeanClassValid(Class<?> beanClass) {
+    return !StringUtils.contains(beanClass.getName(), "org.springframework")
+        && !StringUtils.startsWith(beanClass.getName(), "java")
+        && !StringUtils.startsWith(beanClass.getName(), "jdk")
+        && !StringUtils.contains(beanClass.getName(), "$");
+  }
+
+  private boolean isServiceBean(Class<?> beanClass) {
+    return beanClass.isAnnotationPresent(Component.class) || beanClass.isAnnotationPresent(Service.class);
+  }
+
+  @SuppressWarnings("rawtypes")
+  private Class beanNameToClass(ComponentAdapter adapter, PortalContainer portalContainer) {
+    Object key = adapter.getComponentKey();
+    if (key instanceof Class<?> keyClass) {
+      return keyClass;
+    } else {
+      if (key instanceof String keyString) {
+        try {
+          return portalContainer.getPortalClassLoader().loadClass(keyString);
+        } catch (ClassNotFoundException e) {
+          return adapter.getComponentImplementation();
+        }
+      } else {
+        return key.getClass();
+      }
+    }
+  }
+
+}

--- a/poll-services/src/main/java/io/meeds/spring/integration/package-info.java
+++ b/poll-services/src/main/java/io/meeds/spring/integration/package-info.java
@@ -1,29 +1,24 @@
-/*
+/**
  * This file is part of the Meeds project (https://meeds.io/).
- * 
- * Copyright (C) 2022 Meeds Association contact@meeds.io
- * 
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package io.meeds.poll.dao;
 
-import org.springframework.stereotype.Component;
-
-import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
-
-import io.meeds.poll.entity.PollEntity;
-
-@Component
-public class PollDAO extends GenericDAOJPAImpl<PollEntity, Long> {
-}
+/**
+ * A package that should be moved to a common project (Portal) to allow allow
+ * addons to be able to use it when needed
+ */
+package io.meeds.spring.integration;

--- a/poll-services/src/main/java/io/meeds/spring/integration/web/configuration/WebConfiguration.java
+++ b/poll-services/src/main/java/io/meeds/spring/integration/web/configuration/WebConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.spring.integration.web.configuration;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.core.GrantedAuthorityDefaults;
+import org.springframework.security.web.SecurityFilterChain;
+
+import io.meeds.spring.integration.web.filter.PortalIdentityFilter;
+import io.meeds.spring.integration.web.filter.PortalTransactionFilter;
+import io.meeds.spring.integration.web.security.PortalAuthenticationManager;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true, jsr250Enabled = true)
+public class WebConfiguration {
+
+  @Bean
+  public GrantedAuthorityDefaults grantedAuthorityDefaults() {
+    // Reset prefix to be empty. By default it adds "ROLE_" prefix
+    return new GrantedAuthorityDefaults("");
+  }
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http, PortalAuthenticationManager authenticationProvider) throws Exception {
+    return http.authenticationProvider(authenticationProvider)
+               .authorizeHttpRequests()
+               .antMatchers("/**")
+               .authenticated()
+               .and()
+               .jee()
+               .and()
+               .csrf()
+               .disable()
+               .headers(headers -> {
+                 headers.cacheControl().disable();
+                 headers.frameOptions().disable();
+                 headers.xssProtection().disable();
+                 headers.contentTypeOptions().disable();
+               })
+               .build();
+  }
+
+  @Bean
+  public FilterRegistrationBean<PortalIdentityFilter> identityFilter() {
+    FilterRegistrationBean<PortalIdentityFilter> registrationBean = new FilterRegistrationBean<>();
+
+    registrationBean.setFilter(new PortalIdentityFilter());
+    registrationBean.addUrlPatterns("/rest/*");
+    registrationBean.setOrder(1);
+
+    return registrationBean;
+  }
+
+  @Bean
+  public FilterRegistrationBean<PortalTransactionFilter> transactionFilter() {
+    FilterRegistrationBean<PortalTransactionFilter> registrationBean = new FilterRegistrationBean<>();
+
+    registrationBean.setFilter(new PortalTransactionFilter());
+    registrationBean.addUrlPatterns("/rest/*");
+    registrationBean.setOrder(2);
+
+    return registrationBean;
+  }
+
+}

--- a/poll-services/src/main/java/io/meeds/spring/integration/web/filter/PortalIdentityFilter.java
+++ b/poll-services/src/main/java/io/meeds/spring/integration/web/filter/PortalIdentityFilter.java
@@ -1,29 +1,30 @@
-/*
+/**
  * This file is part of the Meeds project (https://meeds.io/).
- * 
- * Copyright (C) 2022 Meeds Association contact@meeds.io
- * 
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package io.meeds.poll.dao;
 
-import org.springframework.stereotype.Component;
+package io.meeds.spring.integration.web.filter;
 
-import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
+import org.exoplatform.services.security.web.SetCurrentIdentityFilter;
 
-import io.meeds.poll.entity.PollEntity;
+/**
+ * A Web filter to retrieve currently authenticated user Identity to current Web
+ * context session
+ */
+public class PortalIdentityFilter extends SetCurrentIdentityFilter {
 
-@Component
-public class PollDAO extends GenericDAOJPAImpl<PollEntity, Long> {
 }

--- a/poll-services/src/main/java/io/meeds/spring/integration/web/filter/PortalTransactionFilter.java
+++ b/poll-services/src/main/java/io/meeds/spring/integration/web/filter/PortalTransactionFilter.java
@@ -1,0 +1,95 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+package io.meeds.spring.integration.web.filter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.ComponentRequestLifecycle;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.rest.impl.EnvironmentContext;
+
+/**
+ * A class to start a Kernel transaction before any call to Spring REST endpoint
+ */
+public class PortalTransactionFilter implements Filter {
+
+  private static final Log                LOG = ExoLogger.getLogger(PortalTransactionFilter.class);
+
+  private PortalContainer                 container;
+
+  private List<ComponentRequestLifecycle> transactionalServices;
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    if (container == null) {
+      initFilter();
+    }
+    ExoContainerContext.setCurrentContainer(container);
+    RequestLifeCycle.begin(container);
+    try {
+      chain.doFilter(request, response);
+    } finally {
+      Map<Object, Throwable> results = RequestLifeCycle.end();
+      for (Entry<Object, Throwable> entry : results.entrySet()) {
+        if (entry.getValue() != null) {
+          LOG.error("An error occurred while calling the method endRequest on " + entry.getKey(), entry.getValue());
+        }
+      }
+      EnvironmentContext.setCurrent(null);
+      for (ComponentRequestLifecycle service : transactionalServices) {
+        if (service.isStarted(container)) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("The service {} didn't called endRequest, uri = {}, http method = {}. Commit transaction anyway.",
+                      service.getClass().getName(),
+                      ((HttpServletRequest) request).getRequestURI(),
+                      ((HttpServletRequest) request).getMethod());
+          }
+          service.endRequest(container);
+          if (service.isStarted(container)) {
+            LOG.error("The service {} didn't ended properly even after calling endRequest",
+                      service.getClass().getName(),
+                      ((HttpServletRequest) request).getRequestURI(),
+                      ((HttpServletRequest) request).getMethod());
+          }
+        }
+      }
+    }
+  }
+
+  private void initFilter() {
+    container = PortalContainer.getInstance();
+    transactionalServices = container.getComponentInstancesOfType(ComponentRequestLifecycle.class);
+  }
+
+}

--- a/poll-services/src/main/java/io/meeds/spring/integration/web/security/PortalAuthenticationManager.java
+++ b/poll-services/src/main/java/io/meeds/spring/integration/web/security/PortalAuthenticationManager.java
@@ -1,0 +1,173 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.spring.integration.web.security;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.jaas.JaasGrantedAuthority;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.services.security.Authenticator;
+import org.exoplatform.services.security.ConversationRegistry;
+import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.services.security.IdentityConstants;
+import org.exoplatform.services.security.IdentityRegistry;
+import org.exoplatform.services.security.StateKey;
+import org.exoplatform.services.security.web.HttpSessionStateKey;
+
+@Component
+public class PortalAuthenticationManager implements AuthenticationProvider {
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    ServletRequestAttributes requestAttributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+    HttpServletRequest request = requestAttributes.getRequest();
+
+    try {
+      ConversationState conversationState = getCurrentState(request);
+      Principal userPrincipal = request.getUserPrincipal();
+      if (conversationState == null
+          || (!conversationState.getIdentity().isMemberOf("/platform/users")
+              && !conversationState.getIdentity().isMemberOf("/platform/externals"))) {
+        return new AnonymousAuthenticationToken(IdentityConstants.ANONIM,
+                                                authentication.getPrincipal(),
+                                                Collections.singletonList(new JaasGrantedAuthority("guests",
+                                                                                                   userPrincipal)));
+      } else {
+        List<GrantedAuthority> authorities = getAuthorities(conversationState.getIdentity(),
+                                                            userPrincipal);
+        List<GrantedAuthority> extendedAuthorities = getExtendedAuthorities(userPrincipal);
+        if (CollectionUtils.isNotEmpty(extendedAuthorities)) {
+          authorities = new ArrayList<>(authorities);
+          authorities.addAll(extendedAuthorities);
+        }
+        authentication.setAuthenticated(true);
+        return new PreAuthenticatedAuthenticationToken(authentication.getPrincipal(),
+                                                       null,
+                                                       authorities);
+      }
+    } catch (Exception e) {
+      throw new AuthenticationServiceException("An unknown error is encountered while authenticating user", e);
+    }
+  }
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+    return true;
+  }
+
+  public ConversationState getCurrentState(HttpServletRequest httpRequest) throws Exception {
+    ConversationState state = ConversationState.getCurrent();
+    if (state != null) {
+      return state;
+    }
+
+    String userId = httpRequest.getRemoteUser();
+    // only if user authenticated, otherwise there is no reason to do anythings
+    if (userId != null) {
+      StateKey stateKey = new HttpSessionStateKey(httpRequest.getSession());
+
+      state = getStateBySessionId(userId, stateKey);
+      if (state == null) {
+        return buildState(userId, stateKey);
+      } else {
+        return state;
+      }
+    } else {
+      return new ConversationState(new Identity(IdentityConstants.ANONIM));
+    }
+  }
+
+  /**
+   * A method to allow extending attributed roles to user in current portal
+   * context
+   * 
+   * @param  userPrincipal current user {@link Principal}
+   * @return               {@link List} of {@link GrantedAuthority} to add to
+   *                       current user
+   */
+  protected List<GrantedAuthority> getExtendedAuthorities(Principal userPrincipal) {
+    return Collections.emptyList();
+  }
+
+  private List<GrantedAuthority> getAuthorities(Identity identity, Principal principal) {
+    return identity.getRoles()
+                   .stream()
+                   .map(role -> (GrantedAuthority) new JaasGrantedAuthority(role, principal))
+                   .toList();
+  }
+
+  private ConversationState buildState(String userId, StateKey stateKey) throws Exception {
+    Identity identity = buildIdentity(userId);
+    if (identity == null) {
+      return null;
+    } else {
+      return buildState(identity, stateKey);
+    }
+  }
+
+  private ConversationState buildState(Identity identity, StateKey stateKey) {
+    ConversationRegistry conversationRegistry = ExoContainerContext.getService(ConversationRegistry.class);
+
+    ConversationState state = new ConversationState(identity);
+    conversationRegistry.register(stateKey, state);
+    return state;
+  }
+
+  private Identity buildIdentity(String userId) throws Exception {
+    IdentityRegistry identityRegistry = ExoContainerContext.getService(IdentityRegistry.class);
+    Authenticator authenticator = ExoContainerContext.getService(Authenticator.class);
+
+    Identity identity = identityRegistry.getIdentity(userId);
+    if (identity == null) {
+      identity = authenticator.createIdentity(userId);
+      identityRegistry.register(identity);
+    }
+    return identity;
+  }
+
+  private ConversationState getStateBySessionId(String userId, StateKey stateKey) {
+    ConversationRegistry conversationRegistry = ExoContainerContext.getService(ConversationRegistry.class);
+
+    ConversationState state = conversationRegistry.getState(stateKey);
+    if (state != null && !userId.equals(state.getIdentity().getUserId())) {
+      state = null;
+      conversationRegistry.unregister(stateKey, false);
+    }
+    return state;
+  }
+
+}

--- a/poll-services/src/main/resources/conf/portal/configuration.xml
+++ b/poll-services/src/main/resources/conf/portal/configuration.xml
@@ -16,31 +16,6 @@
                xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
                xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
 
-  <component>
-    <type>io.meeds.poll.dao.PollDAO</type>
-  </component>
-
-  <component>
-    <type>io.meeds.poll.dao.PollOptionDAO</type>
-  </component>
-
-  <component>
-    <type>io.meeds.poll.dao.PollVoteDAO</type>
-  </component>
-
-  <component>
-    <key>io.meeds.poll.service.PollService</key>
-    <type>io.meeds.poll.service.PollServiceImpl</type>
-  </component>
-
-  <component>
-    <type>io.meeds.poll.storage.PollStorage</type>
-  </component>
-
-  <component>
-    <type>io.meeds.poll.rest.PollRest</type>
-  </component>
-
   <external-component-plugins>
     <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
     <component-plugin>
@@ -54,46 +29,6 @@
           <value>db/changelog/poll-rdbms.db.changelog-master.xml</value>
         </values-param>
       </init-params>
-    </component-plugin>
-  </external-component-plugins>
-  
-  <external-component-plugins>
-    <target-component>org.exoplatform.social.core.manager.ActivityManager</target-component>
-    <component-plugin>
-      <name>PollActivityProcessor</name>
-      <set-method>addProcessorPlugin</set-method>
-      <type>io.meeds.poll.activity.processor.PollActivityProcessor</type>
-      <init-params>
-        <value-param>
-          <name>priority</name>
-          <description>priority of this processor (lower are executed first)</description>
-          <value>30</value>
-        </value-param>
-      </init-params>
-    </component-plugin>
-  </external-component-plugins>
-
-  <external-component-plugins>
-    <target-component>org.exoplatform.services.listener.ListenerService</target-component>
-    <component-plugin profiles="analytics">
-      <name>meeds.poll.createPoll</name>
-      <set-method>addListener</set-method>
-      <type>io.meeds.poll.listener.AnalyticsPollListener</type>
-    </component-plugin>
-    <component-plugin profiles="analytics">
-      <name>meeds.poll.votePoll</name>
-      <set-method>addListener</set-method>
-      <type>io.meeds.poll.listener.AnalyticsPollListener</type>
-    </component-plugin>
-    <component-plugin profiles="gamification">
-      <name>meeds.poll.createPoll</name>
-      <set-method>addListener</set-method>
-      <type>io.meeds.poll.listener.GamificationPollListener</type>
-    </component-plugin>
-    <component-plugin profiles="gamification">
-      <name>meeds.poll.votePoll</name>
-      <set-method>addListener</set-method>
-      <type>io.meeds.poll.listener.GamificationPollListener</type>
     </component-plugin>
   </external-component-plugins>
 

--- a/poll-services/src/test/resources/conf/exo.poll.service-local-configuration.xml
+++ b/poll-services/src/test/resources/conf/exo.poll.service-local-configuration.xml
@@ -15,6 +15,71 @@
 	xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
 	xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
 
+  <component>
+    <type>io.meeds.poll.dao.PollDAO</type>
+  </component>
+
+  <component>
+    <type>io.meeds.poll.dao.PollOptionDAO</type>
+  </component>
+
+  <component>
+    <type>io.meeds.poll.dao.PollVoteDAO</type>
+  </component>
+
+  <component>
+    <key>io.meeds.poll.service.PollService</key>
+    <type>io.meeds.poll.service.PollServiceImpl</type>
+  </component>
+
+  <component>
+    <type>io.meeds.poll.storage.PollStorage</type>
+  </component>
+
+  <component>
+    <type>io.meeds.poll.rest.PollRest</type>
+  </component>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.social.core.manager.ActivityManager</target-component>
+    <component-plugin>
+      <name>PollActivityProcessor</name>
+      <set-method>addProcessorPlugin</set-method>
+      <type>io.meeds.poll.activity.processor.PollActivityProcessor</type>
+      <init-params>
+        <value-param>
+          <name>priority</name>
+          <description>priority of this processor (lower are executed first)</description>
+          <value>30</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.listener.ListenerService</target-component>
+    <component-plugin profiles="analytics">
+      <name>meeds.poll.createPoll</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.poll.listener.AnalyticsPollListener</type>
+    </component-plugin>
+    <component-plugin profiles="analytics">
+      <name>meeds.poll.votePoll</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.poll.listener.AnalyticsPollListener</type>
+    </component-plugin>
+    <component-plugin profiles="gamification">
+      <name>meeds.poll.createPoll</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.poll.listener.GamificationPollListener</type>
+    </component-plugin>
+    <component-plugin profiles="gamification">
+      <name>meeds.poll.votePoll</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.poll.listener.GamificationPollListener</type>
+    </component-plugin>
+  </external-component-plugins>
+
   <external-component-plugins>
     <target-component>org.exoplatform.services.organization.OrganizationService</target-component>
     <component-plugin>

--- a/poll-webapp/package-lock.json
+++ b/poll-webapp/package-lock.json
@@ -928,6 +928,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -943,7 +945,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -4660,15 +4664,14 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      },
+      "requires": {},
       "dependencies": {
         "ajv": {
-          "version": "8.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -4680,7 +4683,9 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },

--- a/poll-webapp/pom.xml
+++ b/poll-webapp/pom.xml
@@ -10,6 +10,11 @@
   <name>eXo Poll - Application</name>
   <dependencies>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>poll-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.exoplatform.platform-ui</groupId>
       <artifactId>platform-ui-skin</artifactId>
       <classifier>sources</classifier>

--- a/poll-webapp/src/main/java/io/meeds/deeds/PollApplication.java
+++ b/poll-webapp/src/main/java/io/meeds/deeds/PollApplication.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.deeds;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.boot.ApplicationContextFactory;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.PropertySource;
+
+import io.meeds.spring.integration.kernel.PortalApplicationContext;
+
+@SpringBootApplication(
+  scanBasePackages = {
+      "io.meeds.poll",
+      "io.meeds.spring.integration"
+  }
+)
+@EnableCaching
+@PropertySource("classpath:application.properties")
+public class PollApplication extends SpringBootServletInitializer {
+
+  private DefaultListableBeanFactory beanFactory;
+
+  private ServletContext             servletContext;
+
+  @Override
+  public void onStartup(ServletContext servletContext) throws ServletException {
+    // Used to disable LogBack initialization in WebApp context after having
+    // initialized it already in Meeds Server globally
+    System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
+
+    this.servletContext = servletContext;
+    this.beanFactory = new DefaultListableBeanFactory();
+    super.onStartup(servletContext);
+  }
+
+  @Override
+  protected SpringApplicationBuilder createSpringApplicationBuilder() {
+    return new SpringApplicationBuilder() {
+      @Override
+      public SpringApplicationBuilder contextFactory(ApplicationContextFactory factory) {
+        return super.contextFactory(w -> new PortalApplicationContext(servletContext, beanFactory));
+      }
+    };
+  }
+
+}

--- a/poll-webapp/src/main/resources/application.properties
+++ b/poll-webapp/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+spring.main.banner-mode=off
+logging.level.org.springframework: INFO
+application.buildNumber=${buildNumber}
+spring.task.scheduling.pool.size=5
+# Essential to not have collision between Spring Controller DispatcherServlet and Portlet Container Dispatcher
+spring.mvc.servlet.path=/rest/

--- a/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/js/pollService.js
+++ b/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/js/pollService.js
@@ -17,7 +17,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 export const postPoll = (poll, spaceId) => {
-  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/poll?spaceId=${spaceId || ''}`, {
+  return fetch(`/poll/rest/polls?spaceId=${spaceId || ''}`, {
     headers: {
       'Content-Type': 'application/json'
     },
@@ -34,7 +34,7 @@ export const postPoll = (poll, spaceId) => {
 };
 
 export const getPollById = (pollId) => {
-  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/poll/${pollId}`, {
+  return fetch(`/poll/rest/polls/${pollId}`, {
     credentials: 'include',
     method: 'GET',
   }).then(resp => {
@@ -47,7 +47,7 @@ export const getPollById = (pollId) => {
 };
 
 export const vote = (optionId) => {
-  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/poll/vote/${optionId}`, {
+  return fetch(`/poll/rest/poll/vote/${optionId}`, {
     headers: {
       'Content-Type': 'application/json'
     },

--- a/pom.xml
+++ b/pom.xml
@@ -29,12 +29,22 @@
     <org.exoplatform.social.version>6.5.x-SNAPSHOT</org.exoplatform.social.version>
     <org.exoplatform.platform-ui.version>6.5.x-SNAPSHOT</org.exoplatform.platform-ui.version>
     <addon.exo.analytics.version>1.4.x-SNAPSHOT</addon.exo.analytics.version>
-   
+
+    <!-- Spring 5 / Spring Boot 2 -->
+    <spring-boot-dependencies.version>2.7.14</spring-boot-dependencies.version>
+
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>
   </properties>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot-dependencies.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- Import versions from platform project -->
       <dependency>
         <groupId>org.exoplatform.social</groupId>


### PR DESCRIPTION
This PR will integrate a common library classes `io.meeds.spring.integration` that should be defined globally in `gatein-portal` in order to allow integration of any **Kernel** addon using **Spring 5 / Spring Boot 2**.
There are other multiple _possible_ integrations, like using `Spring JPA` instead of custom JPA integration (in order to improve productivity) and the auto generation of a swagger UI for REST endpoints.
In context of this PoC all needed Spring Jars will be added in addon packaging for PoC test purpose only.