### PR TITLE
fix: Remove the extra margin for composer drawer poll icon - MEED-2618 -Meeds-io/MIP#54

### DIFF
--- a/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollComposer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollComposer.vue
@@ -28,7 +28,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       @click="openCreatePollDrawer">
       <v-icon
         color="amber darken-1"
-        class="my-1"
         size="50">
         fa-poll
       </v-icon>


### PR DESCRIPTION
This change will remove the extra margin for composer drawer poll icon.
