### PR TITLE
fix: Fix used meta site name reference - MEED-3024 - Meeds-io/meeds#1351

### DIFF
--- a/poll-webapp/src/main/webapp/vue-app/engagementCenterExtensions/extensions.js
+++ b/poll-webapp/src/main/webapp/vue-app/engagementCenterExtensions/extensions.js
@@ -7,7 +7,7 @@ export function init() {
       icon: 'fas fa-poll',
       match: (actionLabel) => userActions.includes(actionLabel),
       getLink: (realization) => {
-        realization.link = `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/activity?id=${realization.objectId}`;
+        realization.link = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/activity?id=${realization.objectId}`;
         return realization.link;
       }
     },


### PR DESCRIPTION

Prior to this change, the Meta site name was referenced as 'defaultPortal'. The notion of 'default' portal doesn't exist anymore and was replaced by 'meta' site with 'aggregated' sites. This change will replace to use the Meta site name where the list of referenced applications are added.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
