### PR TITLE
fix: Remove drawer width from poll drawer - MEED-3135 - Meeds-io/meeds#1524

### DIFF
--- a/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollDrawer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollDrawer.vue
@@ -20,7 +20,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <exo-drawer
     ref="createPollDrawer"
     id="createPollDrawer"
-    :drawer-width="drawerWidth"
     :right="!$vuetify.rtl"
     allow-expand
     disable-pull-to-refresh>
@@ -131,9 +130,6 @@ export default {
   computed: {
     isMobile() {
       return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
-    },
-    drawerWidth() {
-      return !this.isMobile ? '100%' : '420';
     },
     checkPollOptionalOptions() {
       return this.options.slice(-2).every(option => !option.data || option.data.length <= this.MAX_LENGTH );


### PR DESCRIPTION
Before this fix, when we added the expand option to the poll drawer it's always opened with 100% width due to drawerWidth defined computed value.
This change removes the drawerWidth computed value.