### PR TITLE
fix: fix posting a poll - EXO-5947 - Meeds-io/meeds#1708

### DIFF
--- a/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollComposer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollComposer.vue
@@ -133,6 +133,7 @@ export default {
         .then(() => {
           document.dispatchEvent(new CustomEvent('activity-created', {detail: this.activityId}));
           this.pollAction = 'create';
+          this.updateComposerPollLabel(this.pollAction);
           this.savedPoll = {};
         })
         .catch(error => {

--- a/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollToolbarAction.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollToolbarAction.vue
@@ -96,6 +96,9 @@ export default {
       document.dispatchEvent(new CustomEvent('activity-composer-edited'));
     },
     postPoll(message) {
+      if (!this.savedPoll.question || !this.savedPoll.options ) {
+        return;
+      }
       const poll = {
         question: this.savedPoll.question,
         options: this.savedPoll.options.filter(option => option.data != null && option.data !== '')
@@ -119,6 +122,7 @@ export default {
         .then(() => {
           document.dispatchEvent(new CustomEvent('activity-created', {detail: this.activityId}));
           this.pollAction = 'create';
+          document.dispatchEvent(new CustomEvent('update-composer-poll-label', {detail: 'create'}));
           this.savedPoll = {};
         })
         .catch(error => {


### PR DESCRIPTION
before this change, after posting a poll and reopening the activity drawer to post a new activity or a poll, the toolbar message was not changed and browser errors were displayed I couldn't post any short message
After this change, when reopening the drawer the message label  is updated and the messages are added successfully 