### PR TITLE
fix: fix posting a poll - EXO-69866 - Meeds-io/meeds#1708

### DIFF
--- a/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollComposer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollComposer.vue
@@ -133,6 +133,7 @@ export default {
         .then(() => {
           document.dispatchEvent(new CustomEvent('activity-created', {detail: this.activityId}));
           this.pollAction = 'create';
+          this.updateComposerPollLabel(this.pollAction);
           this.savedPoll = {};
         })
         .catch(error => {

--- a/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollComposer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollComposer.vue
@@ -95,6 +95,7 @@ export default {
     document.addEventListener('update-composer-poll-label', event => {
       this.updateComposerPollLabel(event.detail);
     });
+    document.addEventListener('activity-composer-closed', this.reset);
   },
   methods: {
     openCreatePollDrawer() {
@@ -157,6 +158,11 @@ export default {
         });
         return Promise.all(promises).then(() => activity);
       }
+    },
+    reset() {
+      this.pollAction = 'create';
+      this.updateComposerPollLabel(this.pollAction);
+      this.savedPoll = {};
     },
   },
 };

--- a/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollDrawer.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollDrawer.vue
@@ -195,7 +195,7 @@ export default {
         this.options = JSON.parse(JSON.stringify(this.savedPoll.options));
         Object.assign(this.poll,JSON.parse(JSON.stringify(this.savedPoll)));
       }
-      this.$refs.createPollDrawer.open();
+      this.$nextTick().then(() =>  this.$refs.createPollDrawer.open());
     },
     closeDrawer() {
       this.$refs.createPollDrawer.close();
@@ -212,9 +212,8 @@ export default {
             poll: this.poll
           }}));
           document.dispatchEvent(new CustomEvent('update-composer-poll-label', {detail: 'update'}));
-        } else {
-          this.$emit('poll-created', this.poll);
         }
+        this.$emit('poll-created', this.poll);
         this.closeDrawer();
       }
     },

--- a/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollToolbarAction.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollToolbarAction.vue
@@ -75,6 +75,7 @@ export default {
         document.dispatchEvent(new CustomEvent('activity-composer-edited'));
       }
     });
+    document.addEventListener('activity-composer-closed', this.reset);
   },
   methods: {
     openCreatePollDrawer() {
@@ -146,6 +147,11 @@ export default {
         });
         return Promise.all(promises).then(() => activity);
       }
+    },
+    reset() {
+      this.pollAction = 'create';
+      this.updateComposerPollLabel(this.pollAction);
+      this.savedPoll = {};
     },
   },
 };

--- a/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollToolbarAction.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollToolbarAction.vue
@@ -96,6 +96,9 @@ export default {
       document.dispatchEvent(new CustomEvent('activity-composer-edited'));
     },
     postPoll(message) {
+      if (!this.savedPoll.question || !this.savedPoll.options ) {
+        return;
+      }
       const poll = {
         question: this.savedPoll.question,
         options: this.savedPoll.options.filter(option => option.data != null && option.data !== '')
@@ -119,6 +122,7 @@ export default {
         .then(() => {
           document.dispatchEvent(new CustomEvent('activity-created', {detail: this.activityId}));
           this.pollAction = 'create';
+          document.dispatchEvent(new CustomEvent('update-composer-poll-label', {detail: 'create'}));
           this.savedPoll = {};
         })
         .catch(error => {


### PR DESCRIPTION
before this change, after posting a poll and reopening the activity drawer to post a new activity or a poll, the toolbar message was not changed and browser errors were displayed I couldn't post any short message
After this change, when reopening the drawer the message label is updated, the messages are added successfully and the poll drawer is reset when the activity drawer is closed