### PR TITLE
fix: Avoid using v-app in Vue components not main DOM of an app - MEED-7094 - Meeds-io/MIPs#144

### DIFF
--- a/poll-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/PollEvent.vue
+++ b/poll-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/PollEvent.vue
@@ -17,7 +17,7 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <poll-event-form
       v-if="isEditing"
       :trigger="trigger"
@@ -26,7 +26,7 @@
       v-else
       :trigger="trigger"
       :properties="properties" />
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/poll-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/PollEventDisplay.vue
+++ b/poll-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/PollEventDisplay.vue
@@ -17,7 +17,7 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <template v-if="activityId">
       <div class="subtitle-1 font-weight-bold mb-2">
         {{ $t('gamification.event.display.doItNow') }}
@@ -49,7 +49,7 @@
         :key="space.spaceId"
         :space="space" />
     </template>
-  </v-app>
+  </div>
 </template>
 
 <script>

--- a/poll-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/PollEventForm.vue
+++ b/poll-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/PollEventForm.vue
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <v-card-text class="px-0 pb-0 dark-grey-color font-weight-bold">
       {{ $t('gamification.event.detail.activity.label') }}
     </v-card-text>
@@ -56,7 +56,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <v-list-item-action-text v-if="!isValidLink" class="d-flex py-0 me-0 me-sm-8">
       <span class="error--text">{{ $t('gamification.event.detail.activityLink.error') }}</span>
     </v-list-item-action-text>
-  </v-app>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
Prior to this change, the v-app was used in Vue components injected via extensionRegistry. This change will change it to simply use a simple div.