### PR TITLE
fix: Delete call of inexistant method - Meeds-io/meeds#2285

### DIFF
--- a/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollToolbarAction.vue
+++ b/poll-webapp/src/main/webapp/vue-app/poll-activity-stream-extension/components/CreatePollToolbarAction.vue
@@ -150,7 +150,6 @@ export default {
     },
     reset() {
       this.pollAction = 'create';
-      this.updateComposerPollLabel(this.pollAction);
       this.savedPoll = {};
     },
   },


### PR DESCRIPTION
This change will delete a call to a non-existing method, triggered when the activity composer is closed.

Resolves Meeds-io/meeds#2285