### PR TITLE
feat: Rename Social Web Archive to social - Meeds-io/MIPs#150

### DIFF
--- a/poll-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/poll-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -10,14 +10,14 @@
   </portal-skin>
 
   <portlet-skin>
-    <application-name>social-portlet</application-name>
+    <application-name>social</application-name>
     <portlet-name>UserActivityStreamPortlet</portlet-name>
     <skin-name>Enterprise</skin-name>
     <additional-module>poll</additional-module>
   </portlet-skin>
 
   <portlet-skin>
-    <application-name>social-portlet</application-name>
+    <application-name>social</application-name>
     <portlet-name>SpaceActivityStreamPortlet</portlet-name>
     <skin-name>Enterprise</skin-name>
     <additional-module>poll</additional-module>


### PR DESCRIPTION
This change will rename the Social Web Archive from social-portlet to social.