### PR TITLE
fix: Update default charset and collation for mysql - EXO-75202

### DIFF
--- a/poll-services/src/main/resources/db/changelog/poll-rdbms.db.changelog-1.0.0.xml
+++ b/poll-services/src/main/resources/db/changelog/poll-rdbms.db.changelog-1.0.0.xml
@@ -33,11 +33,13 @@
   </changeSet>
 
   <changeSet author="poll" id="1.0.0-1">
+    <validCheckSum>9:6c06bd4c9da244943d8802ab0f5bdfd7</validCheckSum>
+    <validCheckSum>9:19de057d5accde689dd4a2923ba2776d</validCheckSum>
     <createTable tableName="POLL">
       <column name="POLL_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_POLL"/>
       </column>
-      <column name="QUESTION" type="NVARCHAR(2000)">
+      <column name="QUESTION" type="VARCHAR(2000)">
         <constraints nullable="false"/>
       </column>
       <column name="CREATED_DATE" type="TIMESTAMP" defaultValueComputed="NULL"/>
@@ -54,12 +56,12 @@
       <column name="POLL_ID" type="BIGINT">
         <constraints foreignKeyName="FK_OPTION_POLL" references="POLL(POLL_ID)" nullable="false" />
       </column>
-      <column name="DESCRIPTION" type="NVARCHAR(2000)">
+      <column name="DESCRIPTION" type="VARCHAR(2000)">
         <constraints nullable="false"/>
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -75,6 +77,7 @@
   </changeSet>
 
   <changeSet author="poll" id="1.0.0-4">
+    <validCheckSum>9:15180130844bb18ab33da5d7a650dafd</validCheckSum>
     <createTable tableName="POLL_VOTE">
       <column name="POLL_VOTE_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_POLL_VOTE"/>
@@ -88,12 +91,17 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <changeSet author="poll" id="1.0.0-6">
     <addUniqueConstraint columnNames="POLL_OPTION_ID,VOTER_ID" tableName="POLL_VOTE" />
   </changeSet>
-
+  <changeSet author="poll" id="1.0.0-7" >
+    <sql dbms="mysql">
+      ALTER TABLE POLL_OPTION CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE POLL_VOTE CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+    </sql>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
With mysql 8.4, the default charset and collation are updated from UTF to UTF8MB4. In addition NVARCHAR is now deprecated and replaced by VARCHAR. This commit adapt liquibase changes in order to apply this change.

Resolves Meeds-io/meeds#2564

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
