### PR TITLE
feat: Include All managing spaces including when space template master - MEED-7771 - Meeds-io/MIPs#160

### DIFF
--- a/poll-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/PollEventForm.vue
+++ b/poll-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/PollEventForm.vue
@@ -33,6 +33,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         :labels="spaceSuggesterLabels"
         :include-users="false"
         :width="220"
+        :search-options="{
+          filterType: 'member_or_managing',
+        }"
         name="spacesSuggester"
         class="user-suggester mt-n2"
         include-spaces


### PR DESCRIPTION
This change will allow for a space master to choose a space which is managed/mastered (switch space template configuration) when configuring a poll event in a rule.