### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/poll-services/src/main/java/io/meeds/poll/listener/AnalyticsPollListener.java
+++ b/poll-services/src/main/java/io/meeds/poll/listener/AnalyticsPollListener.java
@@ -104,16 +104,16 @@ public class AnalyticsPollListener extends Listener<String, Poll> {
     statisticData.setSubModule(POLL_MODULE);
     statisticData.setOperation(operation);
     statisticData.setUserId(userId);
-    statisticData.addParameter(POLL_ID, poll.getId());
-    statisticData.addParameter(POLL_ACTIVITY_ID, poll.getActivityId());
-    statisticData.addParameter(POLL_OPTIONS_NUMBER,
-                               pollService.getPollOptionsNumber(poll.getId(),
-                                                                new org.exoplatform.services.security.Identity(userName)));
-    statisticData.addParameter(POLL_DURATION, getPollDuration(poll));
-    statisticData.addParameter(POLL_TOTAL_VOTES,
-                               pollService.getPollTotalVotes(poll.getId(),
-                                                             new org.exoplatform.services.security.Identity(userName)));
-    statisticData.addParameter(POLL_SPACE_MEMBERS_COUNT, getSize(space.getMembers()));
+    statisticData.addKeyword(POLL_ID, poll.getId());
+    statisticData.addKeyword(POLL_ACTIVITY_ID, poll.getActivityId());
+    statisticData.addLong(POLL_OPTIONS_NUMBER,
+                          pollService.getPollOptionsNumber(poll.getId(),
+                                                           new org.exoplatform.services.security.Identity(userName)));
+    statisticData.addLong(POLL_DURATION, getPollDuration(poll));
+    statisticData.addLong(POLL_TOTAL_VOTES,
+                          pollService.getPollTotalVotes(poll.getId(),
+                                                        new org.exoplatform.services.security.Identity(userName)));
+    statisticData.addLong(POLL_SPACE_MEMBERS_COUNT, getSize(space.getMembers()));
 
     AnalyticsUtils.addStatisticData(statisticData);
   }

--- a/poll-webapp/package-lock.json
+++ b/poll-webapp/package-lock.json
@@ -917,6 +917,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -932,7 +934,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -4635,15 +4639,14 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      },
+      "requires": {},
       "dependencies": {
         "ajv": {
-          "version": "8.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -4655,7 +4658,9 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.