### PR TITLE
feat: Add MCP tools for polls (create, vote, results, list)

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -13,4 +13,3 @@ jobs:
         with:
           jdk_major_version: 21
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          extra_maven_opts: -Dsonar.scanner.skipJreProvisioning=true

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -13,3 +13,4 @@ jobs:
         with:
           jdk_major_version: 21
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          extra_maven_opts: -Dsonar.scanner.skipJreProvisioning=true

--- a/poll-services/pom.xml
+++ b/poll-services/pom.xml
@@ -34,6 +34,12 @@
       <artifactId>gamification-services</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!-- MCP Server API -->
+    <dependency>
+      <groupId>io.meeds.mcp-server</groupId>
+      <artifactId>mcp-server-tools</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Test -->
     <dependency>
@@ -46,6 +52,15 @@
   <build>
     <finalName>poll-services</finalName>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.openapitools.swagger</groupId>
         <artifactId>swagger-maven-plugin</artifactId>

--- a/poll-services/src/main/java/io/meeds/poll/mcp/PollMcpTool.java
+++ b/poll-services/src/main/java/io/meeds/poll/mcp/PollMcpTool.java
@@ -20,8 +20,6 @@ package io.meeds.poll.mcp;
 
 import static io.meeds.mcp.server.util.McpToolUtils.formatDate;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -57,14 +55,6 @@ import io.meeds.poll.utils.PollUtils;
 @Service
 @Profile("mcp-server")
 public class PollMcpTool implements McpToolPlugin {
-
-  private static final String ONE_DAY_DURATION    = "1day";
-
-  private static final String THREE_DAYS_DURATION = "3days";
-
-  private static final String ONE_WEEK_DURATION   = "1week";
-
-  private static final String TWO_WEEKS_DURATION  = "2weeks";
 
   private static final int    DEFAULT_LIST_LIMIT  = 10;
 
@@ -109,7 +99,7 @@ public class PollMcpTool implements McpToolPlugin {
     if (cleanOptions.size() < 2) {
       throw new IllegalArgumentException("A poll needs at least 2 non-empty options.");
     }
-    Date endDate = computeEndDate(duration);
+    Date endDate = PollUtils.computeEndDate(new Date(), duration);
 
     Identity identity = getCurrentUserAclIdentity();
     Space space = spaceService.getSpaceById(String.valueOf(spaceId));
@@ -129,13 +119,14 @@ public class PollMcpTool implements McpToolPlugin {
     }).toList();
     String activityMessage = StringUtils.isBlank(message) ? question.trim() : message.trim();
 
+    Poll created;
     try {
-      Poll created = pollService.createPoll(poll, pollOptions, space.getId(), activityMessage, identity, new ArrayList<>());
-      return buildResult(created, identity);
+      created = pollService.createPoll(poll, pollOptions, space.getId(), activityMessage, identity, new ArrayList<>());
     } catch (IllegalAccessException e) {
       throw new IllegalStateException("You are not allowed to create a poll in space '" + space.getDisplayName()
           + "'. Only space members who can post (redactors) may create polls. Tell the user they need redactor rights in that space.");
     }
+    return buildResult(created, identity);
   }
 
   /**
@@ -210,7 +201,7 @@ public class PollMcpTool implements McpToolPlugin {
     if (space == null) {
       throw new IllegalArgumentException("No space found with id " + spaceId + ".");
     }
-    if (!spaceService.canViewSpace(space, identity.getUserId())) {
+    if (!spaceService.isMember(space, identity.getUserId())) {
       throw new IllegalStateException("You are not allowed to view space '" + space.getDisplayName()
           + "'. You must be a member of the space to list its polls.");
     }
@@ -279,29 +270,6 @@ public class PollMcpTool implements McpToolPlugin {
     } catch (RuntimeException e) {
       return null;
     }
-  }
-
-  private Date computeEndDate(String duration) {
-    ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
-    ZonedDateTime end;
-    switch (StringUtils.trimToEmpty(duration)) {
-    case ONE_DAY_DURATION:
-      end = now.plusDays(1);
-      break;
-    case THREE_DAYS_DURATION:
-      end = now.plusDays(3);
-      break;
-    case ONE_WEEK_DURATION:
-      end = now.plusDays(7);
-      break;
-    case TWO_WEEKS_DURATION:
-      end = now.plusDays(14);
-      break;
-    default:
-      throw new IllegalArgumentException("Invalid duration '" + duration
-          + "'. Allowed values are: 1day, 3days, 1week, 2weeks.");
-    }
-    return Date.from(end.toInstant());
   }
 
 }

--- a/poll-services/src/main/java/io/meeds/poll/mcp/PollMcpTool.java
+++ b/poll-services/src/main/java/io/meeds/poll/mcp/PollMcpTool.java
@@ -1,0 +1,307 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.poll.mcp;
+
+import static io.meeds.mcp.server.util.McpToolUtils.formatDate;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.common.RealtimeListAccess;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
+import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+
+import io.meeds.mcp.server.plugin.McpToolPlugin;
+import io.meeds.poll.mcp.model.PollOptionResultModel;
+import io.meeds.poll.mcp.model.PollResultModel;
+import io.meeds.poll.model.Poll;
+import io.meeds.poll.model.PollOption;
+import io.meeds.poll.service.PollService;
+import io.meeds.poll.utils.PollUtils;
+
+/**
+ * MCP tools exposing the Poll add-on to the AI agent (EVA). Every method acts
+ * as the current user, so space membership and redactor permissions are
+ * enforced by {@link PollService}.
+ */
+@Service
+@Profile("mcp-server")
+public class PollMcpTool implements McpToolPlugin {
+
+  private static final String ONE_DAY_DURATION    = "1day";
+
+  private static final String THREE_DAYS_DURATION = "3days";
+
+  private static final String ONE_WEEK_DURATION   = "1week";
+
+  private static final String TWO_WEEKS_DURATION  = "2weeks";
+
+  private static final int    DEFAULT_LIST_LIMIT  = 10;
+
+  private static final int    MAX_LIST_LIMIT      = 20;
+
+  private static final int    ACTIVITY_SCAN_LIMIT = 200;
+
+  private final PollService   pollService;
+
+  private final SpaceService  spaceService;
+
+  private final IdentityManager identityManager;
+
+  private final ActivityManager activityManager;
+
+  public PollMcpTool(PollService pollService,
+                     SpaceService spaceService,
+                     IdentityManager identityManager,
+                     ActivityManager activityManager) {
+    this.pollService = pollService;
+    this.spaceService = spaceService;
+    this.identityManager = identityManager;
+    this.activityManager = activityManager;
+  }
+
+  /**
+   * Creates a poll (with its options) and posts it to a space activity stream.
+   */
+  public PollResultModel createPoll(Long spaceId,
+                                    String question,
+                                    List<String> options,
+                                    String duration,
+                                    String message) throws IllegalAccessException {
+    if (spaceId == null) {
+      throw new IllegalArgumentException("space_id is required. Resolve the target space id first (e.g. with get_my_spaces).");
+    }
+    if (StringUtils.isBlank(question)) {
+      throw new IllegalArgumentException("question is required and cannot be empty.");
+    }
+    List<String> cleanOptions = options == null ? List.of()
+                                                : options.stream().filter(StringUtils::isNotBlank).map(String::trim).toList();
+    if (cleanOptions.size() < 2) {
+      throw new IllegalArgumentException("A poll needs at least 2 non-empty options.");
+    }
+    Date endDate = computeEndDate(duration);
+
+    Identity identity = getCurrentUserAclIdentity();
+    Space space = spaceService.getSpaceById(String.valueOf(spaceId));
+    if (space == null) {
+      throw new IllegalArgumentException("No space found with id " + spaceId
+          + ". Ask the user which space to post the poll in and resolve its id.");
+    }
+
+    Poll poll = new Poll();
+    poll.setQuestion(question.trim());
+    poll.setCreatedDate(new Date());
+    poll.setEndDate(endDate);
+    List<PollOption> pollOptions = cleanOptions.stream().map(desc -> {
+      PollOption pollOption = new PollOption();
+      pollOption.setDescription(desc);
+      return pollOption;
+    }).toList();
+    String activityMessage = StringUtils.isBlank(message) ? question.trim() : message.trim();
+
+    try {
+      Poll created = pollService.createPoll(poll, pollOptions, space.getId(), activityMessage, identity, new ArrayList<>());
+      return buildResult(created, identity);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You are not allowed to create a poll in space '" + space.getDisplayName()
+          + "'. Only space members who can post (redactors) may create polls. Tell the user they need redactor rights in that space.");
+    }
+  }
+
+  /**
+   * Casts the current user's vote for a poll option and returns the updated
+   * results.
+   */
+  public PollResultModel voteInPoll(Long pollOptionId) throws IllegalAccessException, ObjectNotFoundException {
+    if (pollOptionId == null) {
+      throw new IllegalArgumentException("poll_option_id is required. Call get_poll_results first to obtain the option ids.");
+    }
+    Identity identity = getCurrentUserAclIdentity();
+    PollOption option;
+    try {
+      option = pollService.getPollOptionById(pollOptionId, identity);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You are not allowed to access this poll option. You must be a member of the poll's space to vote.");
+    }
+    if (option == null) {
+      throw new ObjectNotFoundException("No poll option found with id " + pollOptionId
+          + ". Call get_poll_results to list the valid option ids.");
+    }
+    Poll poll = pollService.getPollById(option.getPollId(), identity);
+    if (poll == null) {
+      throw new ObjectNotFoundException("The poll for option " + pollOptionId + " no longer exists.");
+    }
+    if (isClosed(poll)) {
+      throw new IllegalStateException("This poll is closed (it ended on " + formatDate(poll.getEndDate())
+          + "); voting is no longer possible.");
+    }
+    if (pollService.didVote(identity, poll.getId())) {
+      throw new IllegalStateException("You have already voted in this poll. Each user can vote only once."
+          + " Call get_poll_results to see the current results.");
+    }
+    try {
+      pollService.vote(String.valueOf(pollOptionId), String.valueOf(poll.getSpaceId()), identity);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You are not allowed to vote in this poll. You must be a member of the poll's space.");
+    }
+    return buildResult(poll, identity);
+  }
+
+  /**
+   * Returns a poll's question, options and current vote tallies.
+   */
+  public PollResultModel getPollResults(Long pollId) throws IllegalAccessException, ObjectNotFoundException {
+    if (pollId == null) {
+      throw new IllegalArgumentException("poll_id is required.");
+    }
+    Identity identity = getCurrentUserAclIdentity();
+    Poll poll;
+    try {
+      poll = pollService.getPollById(pollId, identity);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You are not allowed to view this poll. You must be a member of the poll's space.");
+    }
+    if (poll == null) {
+      throw new ObjectNotFoundException("No poll found with id " + pollId + ".");
+    }
+    return buildResult(poll, identity);
+  }
+
+  /**
+   * Lists the polls posted in a space (most recent first) with their ids and
+   * current results, so a poll can be found without knowing its id.
+   */
+  public List<PollResultModel> listSpacePolls(Long spaceId, Integer limit) {
+    if (spaceId == null) {
+      throw new IllegalArgumentException("space_id is required. Resolve the target space id first (e.g. with get_my_spaces).");
+    }
+    Identity identity = getCurrentUserAclIdentity();
+    Space space = spaceService.getSpaceById(String.valueOf(spaceId));
+    if (space == null) {
+      throw new IllegalArgumentException("No space found with id " + spaceId + ".");
+    }
+    if (!spaceService.canViewSpace(space, identity.getUserId())) {
+      throw new IllegalStateException("You are not allowed to view space '" + space.getDisplayName()
+          + "'. You must be a member of the space to list its polls.");
+    }
+    int max = (limit == null || limit <= 0) ? DEFAULT_LIST_LIMIT : Math.min(limit, MAX_LIST_LIMIT);
+    org.exoplatform.social.core.identity.model.Identity spaceIdentity =
+        identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, space.getPrettyName());
+    RealtimeListAccess<ExoSocialActivity> listAccess = activityManager.getActivitiesOfSpaceWithListAccess(spaceIdentity);
+    int scan = Math.min(listAccess.getSize(), ACTIVITY_SCAN_LIMIT);
+    List<ExoSocialActivity> activities = scan == 0 ? List.of() : listAccess.loadAsList(0, scan);
+
+    List<PollResultModel> polls = new ArrayList<>();
+    for (ExoSocialActivity activity : activities) {
+      if (polls.size() >= max) {
+        break;
+      }
+      Map<String, String> params = activity.getTemplateParams();
+      if (!PollUtils.POLL_ACTIVITY_TYPE.equals(activity.getType()) || params == null
+          || !params.containsKey(PollUtils.POLL_ID)) {
+        continue;
+      }
+      try {
+        Poll poll = pollService.getPollById(Long.parseLong(params.get(PollUtils.POLL_ID)), identity);
+        if (poll != null) {
+          polls.add(buildResult(poll, identity));
+        }
+      } catch (NumberFormatException | IllegalAccessException e) {
+        // skip polls the current user cannot read or with a malformed reference
+      }
+    }
+    return polls;
+  }
+
+  private PollResultModel buildResult(Poll poll, Identity identity) throws IllegalAccessException {
+    long pollId = poll.getId();
+    String spaceId = String.valueOf(poll.getSpaceId());
+    List<PollOption> options = pollService.getPollOptionsByPollId(pollId, identity);
+    int total = pollService.getPollTotalVotes(pollId, identity);
+    boolean didVote = pollService.didVote(identity, pollId);
+    List<PollOptionResultModel> optionModels = new ArrayList<>();
+    for (PollOption option : options) {
+      int votes = pollService.getPollOptionTotalVotes(option.getId(), spaceId, identity);
+      boolean votedByMe = pollService.isPollOptionVoted(option.getId(), spaceId, identity);
+      int percentage = total > 0 ? Math.round(votes * 100f / total) : 0;
+      optionModels.add(new PollOptionResultModel(option.getId(), option.getDescription(), votes, percentage, votedByMe));
+    }
+    return new PollResultModel(pollId,
+                               poll.getQuestion(),
+                               poll.getSpaceId(),
+                               poll.getActivityId(),
+                               resolveUsername(poll.getCreatorId()),
+                               formatDate(poll.getEndDate()),
+                               isClosed(poll),
+                               total,
+                               didVote,
+                               optionModels);
+  }
+
+  private boolean isClosed(Poll poll) {
+    return poll.getEndDate() == null || !poll.getEndDate().after(new Date());
+  }
+
+  private String resolveUsername(long identityId) {
+    try {
+      org.exoplatform.social.core.identity.model.Identity identity = identityManager.getIdentity(String.valueOf(identityId));
+      return identity == null ? null : identity.getRemoteId();
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  private Date computeEndDate(String duration) {
+    ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+    ZonedDateTime end;
+    switch (StringUtils.trimToEmpty(duration)) {
+    case ONE_DAY_DURATION:
+      end = now.plusDays(1);
+      break;
+    case THREE_DAYS_DURATION:
+      end = now.plusDays(3);
+      break;
+    case ONE_WEEK_DURATION:
+      end = now.plusDays(7);
+      break;
+    case TWO_WEEKS_DURATION:
+      end = now.plusDays(14);
+      break;
+    default:
+      throw new IllegalArgumentException("Invalid duration '" + duration
+          + "'. Allowed values are: 1day, 3days, 1week, 2weeks.");
+    }
+    return Date.from(end.toInstant());
+  }
+
+}

--- a/poll-services/src/main/java/io/meeds/poll/mcp/model/PollOptionResultModel.java
+++ b/poll-services/src/main/java/io/meeds/poll/mcp/model/PollOptionResultModel.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.poll.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PollOptionResultModel {
+
+  @JsonProperty("poll_option_id")
+  private long    id;
+
+  private String  description;
+
+  private int     votes;
+
+  private int     percentage;
+
+  @JsonProperty("voted_by_me")
+  private boolean votedByMe;
+
+}

--- a/poll-services/src/main/java/io/meeds/poll/mcp/model/PollResultModel.java
+++ b/poll-services/src/main/java/io/meeds/poll/mcp/model/PollResultModel.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.poll.mcp.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PollResultModel {
+
+  @JsonProperty("poll_id")
+  private long                        id;
+
+  private String                      question;
+
+  @JsonProperty("space_id")
+  private long                        spaceId;
+
+  @JsonProperty("activity_id")
+  private long                        activityId;
+
+  private String                      creator;
+
+  @JsonProperty("end_date")
+  private String                      endDate;
+
+  private boolean                     closed;
+
+  @JsonProperty("total_votes")
+  private int                         totalVotes;
+
+  @JsonProperty("did_vote")
+  private boolean                     didVote;
+
+  private List<PollOptionResultModel> options;
+
+}

--- a/poll-services/src/main/java/io/meeds/poll/utils/PollUtils.java
+++ b/poll-services/src/main/java/io/meeds/poll/utils/PollUtils.java
@@ -18,9 +18,12 @@
  */
 package io.meeds.poll.utils;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.listener.ListenerService;
@@ -34,6 +37,14 @@ import io.meeds.poll.model.Poll;
 public class PollUtils {
 
   private static final Log   LOG                               = ExoLogger.getLogger(PollUtils.class);
+
+  public static final String ONE_DAY_DURATION                 = "1day";
+
+  public static final String THREE_DAYS_DURATION              = "3days";
+
+  public static final String ONE_WEEK_DURATION                = "1week";
+
+  public static final String TWO_WEEKS_DURATION               = "2weeks";
 
   public static final String POLL_ACTIVITY_TYPE                = "poll";
 
@@ -112,5 +123,28 @@ public class PollUtils {
   public static long getPollDuration(Poll poll) {
     long duration = Math.abs(poll.getEndDate().getTime() - poll.getCreatedDate().getTime());
     return TimeUnit.DAYS.convert(duration, TimeUnit.MILLISECONDS);
+  }
+
+  public static Date computeEndDate(Date fromDate, String duration) {
+    ZonedDateTime start = ZonedDateTime.ofInstant(fromDate.toInstant(), ZoneOffset.UTC);
+    ZonedDateTime end;
+    switch (StringUtils.trimToEmpty(duration)) {
+    case ONE_DAY_DURATION:
+      end = start.plusDays(1);
+      break;
+    case THREE_DAYS_DURATION:
+      end = start.plusDays(3);
+      break;
+    case ONE_WEEK_DURATION:
+      end = start.plusDays(7);
+      break;
+    case TWO_WEEKS_DURATION:
+      end = start.plusDays(14);
+      break;
+    default:
+      throw new IllegalArgumentException("Invalid duration '" + duration
+          + "'. Allowed values are: 1day, 3days, 1week, 2weeks.");
+    }
+    return toDate(end);
   }
 }

--- a/poll-services/src/main/java/io/meeds/poll/utils/RestEntityBuilder.java
+++ b/poll-services/src/main/java/io/meeds/poll/utils/RestEntityBuilder.java
@@ -18,8 +18,6 @@
  */
 package io.meeds.poll.utils;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -36,14 +34,6 @@ import io.meeds.poll.rest.model.PollRestEntity;
 import io.meeds.poll.service.PollService;
 
 public class RestEntityBuilder {
-  
-  private static final String ONE_DAY_DURATION = "1day";
-  
-  private static final String THREE_DAYS_DURATION = "3days";
-  
-  private static final String ONE_WEEK_DURATION = "1week";
-  
-  private static final String TWO_WEEKS_DURATION = "2weeks";
 
   private RestEntityBuilder() {
   }
@@ -93,28 +83,14 @@ public class RestEntityBuilder {
 
   public static final Poll toPoll(PollRestEntity pollRestEntity) {
     Date createdDate = new Date();
-    ZonedDateTime createdZonedDateTime = ZonedDateTime.ofInstant(createdDate.toInstant(), ZoneOffset.UTC);
-    ZonedDateTime endZonedDateTime = null;
-    switch (pollRestEntity.getDuration()) {
-    case ONE_DAY_DURATION:
-      endZonedDateTime = createdZonedDateTime.plusDays(1);
-      break;
-    case THREE_DAYS_DURATION:
-      endZonedDateTime = createdZonedDateTime.plusDays(3);
-      break;
-    case ONE_WEEK_DURATION:
-      endZonedDateTime = createdZonedDateTime.plusDays(7);
-      break;
-    case TWO_WEEKS_DURATION:
-      endZonedDateTime = createdZonedDateTime.plusDays(14);
-      break;
-    default:
-      throw new IllegalStateException("Unexpected value: " + pollRestEntity.getDuration());
-    }
     Poll poll = new Poll();
     poll.setQuestion(pollRestEntity.getQuestion());
     poll.setCreatedDate(createdDate);
-    poll.setEndDate(PollUtils.toDate(endZonedDateTime));
+    try {
+      poll.setEndDate(PollUtils.computeEndDate(createdDate, pollRestEntity.getDuration()));
+    } catch (IllegalArgumentException e) {
+      throw new IllegalStateException(e.getMessage());
+    }
     return poll;
   }
 

--- a/poll-services/src/main/resources/ai-tool-definitions.json
+++ b/poll-services/src/main/resources/ai-tool-definitions.json
@@ -1,0 +1,130 @@
+{
+  "tools": [
+    {
+      "name": "create_poll",
+      "title": "Create a poll",
+      "description": "Create a poll (a question with at least two options) and post it to a space activity stream. The current user must be a member who can post (redactor) in the target space. Returns the created poll with its option ids.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "space_id": {
+            "type": "integer",
+            "description": "Identifier of the space where the poll activity is posted (required). Resolve it first with get_my_spaces or get_all_spaces."
+          },
+          "question": {
+            "type": "string",
+            "description": "The poll question (required)."
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The answer options, at least two non-empty entries (required)."
+          },
+          "duration": {
+            "type": "string",
+            "enum": [
+              "1day",
+              "3days",
+              "1week",
+              "2weeks"
+            ],
+            "description": "How long the poll stays open before it closes (required)."
+          },
+          "message": {
+            "type": "string",
+            "description": "Optional message shown on the poll activity. Defaults to the question when omitted."
+          }
+        },
+        "required": [
+          "space_id",
+          "question",
+          "options",
+          "duration"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "vote_in_poll",
+      "title": "Vote in a poll",
+      "description": "Cast the current user's vote for a poll option and return the updated results. The user must be a member of the poll's space, the poll must still be open, and each user can vote only once. Get the option ids from get_poll_results first.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "poll_option_id": {
+            "type": "integer",
+            "description": "Identifier of the poll option to vote for (required). Obtain it from get_poll_results."
+          }
+        },
+        "required": [
+          "poll_option_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "get_poll_results",
+      "title": "Get poll results",
+      "description": "Get a poll's question, options and current vote tallies (per-option counts and percentages, total votes, whether the poll is closed and whether the current user has already voted) from its poll id. The user must be a member of the poll's space. If you do not know the poll id, call list_space_polls first to find it.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "poll_id": {
+            "type": "integer",
+            "description": "Identifier of the poll (required)."
+          }
+        },
+        "required": [
+          "poll_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "list_space_polls",
+      "title": "List polls in a space",
+      "description": "List the polls posted in a space (most recent first), each with its poll id, question, options (with their option ids) and current results. Use this to find a poll's id and its option ids from a space name or id before calling get_poll_results or vote_in_poll. The current user must be a member of the space.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "space_id": {
+            "type": "integer",
+            "description": "Identifier of the space whose polls to list (required). Resolve it first with get_my_spaces or get_all_spaces."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of polls to return (default 10, max 20)."
+          }
+        },
+        "required": [
+          "space_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    }
+  ]
+}

--- a/poll-services/src/test/java/io/meeds/poll/mcp/PollMcpToolTest.java
+++ b/poll-services/src/test/java/io/meeds/poll/mcp/PollMcpToolTest.java
@@ -46,12 +46,12 @@ import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import io.meeds.poll.utils.PollUtils;
 
 import io.meeds.poll.mcp.model.PollResultModel;
 import io.meeds.poll.model.Poll;
 import io.meeds.poll.model.PollOption;
 import io.meeds.poll.service.PollService;
+import io.meeds.poll.utils.PollUtils;
 
 class PollMcpToolTest {
 
@@ -178,6 +178,22 @@ class PollMcpToolTest {
                  () -> pollMcpTool.createPoll(SPACE_ID, "Q", List.of("a", "b"), "1day", null));
   }
 
+  @Test
+  void createPollDoesNotMaskResultBuildingFailureAsCreationFailure() throws Exception {
+    Space space = new Space();
+    space.setId(String.valueOf(SPACE_ID));
+    space.setDisplayName("Engineering");
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+    Poll created = openPoll();
+    when(pollService.createPoll(any(), any(), eq(space.getId()), any(), any(), any())).thenReturn(created);
+    when(pollService.getPollOptionsByPollId(eq(created.getId()), any()))
+        .thenThrow(new IllegalAccessException("transient read failure after successful creation"));
+
+    assertThrows(IllegalAccessException.class,
+                 () -> pollMcpTool.createPoll(SPACE_ID, "Best day for the offsite?",
+                                              List.of("Monday", "Friday"), "1week", null));
+  }
+
   // --- vote_in_poll --------------------------------------------------------
 
   @Test
@@ -271,7 +287,7 @@ class PollMcpToolTest {
     space.setPrettyName("engineering");
     space.setDisplayName("Engineering");
     when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
-    when(spaceService.canViewSpace(eq(space), eq(USERNAME))).thenReturn(true);
+    when(spaceService.isMember(eq(space), eq(USERNAME))).thenReturn(true);
     when(identityManager.getOrCreateIdentity(any(), any()))
         .thenReturn(new org.exoplatform.social.core.identity.model.Identity("1"));
 
@@ -310,7 +326,7 @@ class PollMcpToolTest {
     space.setId(String.valueOf(SPACE_ID));
     space.setDisplayName("Engineering");
     when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
-    when(spaceService.canViewSpace(eq(space), eq(USERNAME))).thenReturn(false);
+    when(spaceService.isMember(eq(space), eq(USERNAME))).thenReturn(false);
     assertThrows(IllegalStateException.class, () -> pollMcpTool.listSpacePolls(SPACE_ID, null));
   }
 

--- a/poll-services/src/test/java/io/meeds/poll/mcp/PollMcpToolTest.java
+++ b/poll-services/src/test/java/io/meeds/poll/mcp/PollMcpToolTest.java
@@ -1,0 +1,317 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.poll.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.common.RealtimeListAccess;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
+import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import io.meeds.poll.utils.PollUtils;
+
+import io.meeds.poll.mcp.model.PollResultModel;
+import io.meeds.poll.model.Poll;
+import io.meeds.poll.model.PollOption;
+import io.meeds.poll.service.PollService;
+
+class PollMcpToolTest {
+
+  private static final String    USERNAME  = "testuser1";
+
+  private static final long      POLL_ID   = 7L;
+
+  private static final long      SPACE_ID  = 3L;
+
+  private static final long      OPTION_A  = 10L;
+
+  private static final long      OPTION_B  = 11L;
+
+  private PollService            pollService;
+
+  private SpaceService          spaceService;
+
+  private IdentityManager       identityManager;
+
+  private ActivityManager       activityManager;
+
+  private Identity              currentIdentity;
+
+  private PollMcpTool           pollMcpTool;
+
+  @BeforeEach
+  void setUp() {
+    pollService = Mockito.mock(PollService.class);
+    spaceService = Mockito.mock(SpaceService.class);
+    identityManager = Mockito.mock(IdentityManager.class);
+    activityManager = Mockito.mock(ActivityManager.class);
+    currentIdentity = new Identity(USERNAME);
+    pollMcpTool = new PollMcpTool(pollService, spaceService, identityManager, activityManager) {
+      @Override
+      public Identity getCurrentUserAclIdentity() {
+        return currentIdentity;
+      }
+    };
+  }
+
+  private Poll openPoll() {
+    Poll poll = new Poll();
+    poll.setId(POLL_ID);
+    poll.setQuestion("Best day for the offsite?");
+    poll.setSpaceId(SPACE_ID);
+    poll.setActivityId(99L);
+    poll.setCreatorId(42L);
+    poll.setCreatedDate(new Date());
+    poll.setEndDate(new Date(System.currentTimeMillis() + 86_400_000L)); // +1 day
+    return poll;
+  }
+
+  private void stubResults(Poll poll, int votesA, int votesB, boolean didVote) throws IllegalAccessException {
+    PollOption a = new PollOption();
+    a.setId(OPTION_A);
+    a.setPollId(poll.getId());
+    a.setDescription("Monday");
+    PollOption b = new PollOption();
+    b.setId(OPTION_B);
+    b.setPollId(poll.getId());
+    b.setDescription("Friday");
+    when(pollService.getPollOptionsByPollId(eq(poll.getId()), any())).thenReturn(List.of(a, b));
+    when(pollService.getPollTotalVotes(eq(poll.getId()), any())).thenReturn(votesA + votesB);
+    when(pollService.didVote(any(), eq(poll.getId()))).thenReturn(didVote);
+    when(pollService.getPollOptionTotalVotes(eq(OPTION_A), any(), any())).thenReturn(votesA);
+    when(pollService.getPollOptionTotalVotes(eq(OPTION_B), any(), any())).thenReturn(votesB);
+    lenient().when(pollService.isPollOptionVoted(eq(OPTION_A), any(), any())).thenReturn(false);
+    lenient().when(pollService.isPollOptionVoted(eq(OPTION_B), any(), any())).thenReturn(didVote);
+  }
+
+  // --- create_poll ---------------------------------------------------------
+
+  @Test
+  void createPoll() throws Exception {
+    Space space = new Space();
+    space.setId(String.valueOf(SPACE_ID));
+    space.setDisplayName("Engineering");
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+    Poll created = openPoll();
+    when(pollService.createPoll(any(), any(), eq(space.getId()), any(), any(), any())).thenReturn(created);
+    stubResults(created, 0, 0, false);
+
+    PollResultModel result = pollMcpTool.createPoll(SPACE_ID, "Best day for the offsite?",
+                                                    List.of("Monday", "Friday"), "1week", null);
+
+    assertNotNull(result);
+    assertEquals(POLL_ID, result.getId());
+    assertEquals(2, result.getOptions().size());
+    assertFalse(result.isClosed());
+    verify(pollService).createPoll(any(), any(), eq(space.getId()), any(), any(), any());
+  }
+
+  @Test
+  void createPollInvalidDurationFails() {
+    Space space = new Space();
+    space.setId(String.valueOf(SPACE_ID));
+    lenient().when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+    assertThrows(IllegalArgumentException.class,
+                 () -> pollMcpTool.createPoll(SPACE_ID, "Q", List.of("a", "b"), "1month", null));
+  }
+
+  @Test
+  void createPollWithLessThanTwoOptionsFails() {
+    assertThrows(IllegalArgumentException.class,
+                 () -> pollMcpTool.createPoll(SPACE_ID, "Q", List.of("only one"), "1day", null));
+  }
+
+  @Test
+  void createPollWithUnknownSpaceFails() {
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(null);
+    assertThrows(IllegalArgumentException.class,
+                 () -> pollMcpTool.createPoll(SPACE_ID, "Q", List.of("a", "b"), "1day", null));
+  }
+
+  @Test
+  void createPollWithoutRedactorRightsFails() throws Exception {
+    Space space = new Space();
+    space.setId(String.valueOf(SPACE_ID));
+    space.setDisplayName("Engineering");
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+    when(pollService.createPoll(any(), any(), any(), any(), any(), any()))
+        .thenThrow(new IllegalAccessException("no rights"));
+    assertThrows(IllegalStateException.class,
+                 () -> pollMcpTool.createPoll(SPACE_ID, "Q", List.of("a", "b"), "1day", null));
+  }
+
+  // --- vote_in_poll --------------------------------------------------------
+
+  @Test
+  void voteInPoll() throws Exception {
+    Poll poll = openPoll();
+    PollOption option = new PollOption();
+    option.setId(OPTION_A);
+    option.setPollId(POLL_ID);
+    when(pollService.getPollOptionById(eq(OPTION_A), any())).thenReturn(option);
+    when(pollService.getPollById(eq(POLL_ID), any())).thenReturn(poll);
+    stubResults(poll, 1, 0, false);
+
+    PollResultModel result = pollMcpTool.voteInPoll(OPTION_A);
+
+    assertNotNull(result);
+    assertEquals(1, result.getTotalVotes());
+    verify(pollService).vote(eq(String.valueOf(OPTION_A)), eq(String.valueOf(SPACE_ID)), any());
+  }
+
+  @Test
+  void voteInPollUnknownOptionFails() throws Exception {
+    when(pollService.getPollOptionById(eq(OPTION_A), any())).thenReturn(null);
+    assertThrows(ObjectNotFoundException.class, () -> pollMcpTool.voteInPoll(OPTION_A));
+  }
+
+  @Test
+  void voteInPollAlreadyVotedFails() throws Exception {
+    Poll poll = openPoll();
+    PollOption option = new PollOption();
+    option.setId(OPTION_A);
+    option.setPollId(POLL_ID);
+    when(pollService.getPollOptionById(eq(OPTION_A), any())).thenReturn(option);
+    when(pollService.getPollById(eq(POLL_ID), any())).thenReturn(poll);
+    when(pollService.didVote(any(), eq(POLL_ID))).thenReturn(true);
+    assertThrows(IllegalStateException.class, () -> pollMcpTool.voteInPoll(OPTION_A));
+  }
+
+  @Test
+  void voteInClosedPollFails() throws Exception {
+    Poll poll = openPoll();
+    poll.setEndDate(new Date(System.currentTimeMillis() - 86_400_000L)); // ended yesterday
+    PollOption option = new PollOption();
+    option.setId(OPTION_A);
+    option.setPollId(POLL_ID);
+    when(pollService.getPollOptionById(eq(OPTION_A), any())).thenReturn(option);
+    when(pollService.getPollById(eq(POLL_ID), any())).thenReturn(poll);
+    assertThrows(IllegalStateException.class, () -> pollMcpTool.voteInPoll(OPTION_A));
+  }
+
+  // --- get_poll_results ----------------------------------------------------
+
+  @Test
+  void getPollResults() throws Exception {
+    Poll poll = openPoll();
+    when(pollService.getPollById(eq(POLL_ID), any())).thenReturn(poll);
+    stubResults(poll, 3, 1, true);
+
+    PollResultModel result = pollMcpTool.getPollResults(POLL_ID);
+
+    assertNotNull(result);
+    assertEquals(4, result.getTotalVotes());
+    assertTrue(result.isDidVote());
+    assertEquals(75, result.getOptions().get(0).getPercentage());
+    assertEquals(25, result.getOptions().get(1).getPercentage());
+  }
+
+  @Test
+  void getPollResultsNotFoundFails() throws Exception {
+    when(pollService.getPollById(eq(POLL_ID), any())).thenReturn(null);
+    assertThrows(ObjectNotFoundException.class, () -> pollMcpTool.getPollResults(POLL_ID));
+  }
+
+  @Test
+  void getPollResultsUnauthorizedFails() throws Exception {
+    when(pollService.getPollById(eq(POLL_ID), any())).thenThrow(new IllegalAccessException("nope"));
+    assertThrows(IllegalStateException.class, () -> pollMcpTool.getPollResults(POLL_ID));
+  }
+
+  @Test
+  void voteInPollNullFails() {
+    assertThrows(IllegalArgumentException.class, () -> pollMcpTool.voteInPoll(null));
+  }
+
+  // --- list_space_polls ----------------------------------------------------
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void listSpacePolls() throws Exception {
+    Space space = new Space();
+    space.setId(String.valueOf(SPACE_ID));
+    space.setPrettyName("engineering");
+    space.setDisplayName("Engineering");
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+    when(spaceService.canViewSpace(eq(space), eq(USERNAME))).thenReturn(true);
+    when(identityManager.getOrCreateIdentity(any(), any()))
+        .thenReturn(new org.exoplatform.social.core.identity.model.Identity("1"));
+
+    ExoSocialActivity pollActivity = new ExoSocialActivityImpl();
+    pollActivity.setType(PollUtils.POLL_ACTIVITY_TYPE);
+    pollActivity.setTemplateParams(java.util.Map.of(PollUtils.POLL_ID, String.valueOf(POLL_ID)));
+    ExoSocialActivity otherActivity = new ExoSocialActivityImpl();
+    otherActivity.setType("DEFAULT_ACTIVITY");
+
+    RealtimeListAccess<ExoSocialActivity> listAccess = Mockito.mock(RealtimeListAccess.class);
+    when(listAccess.getSize()).thenReturn(2);
+    when(listAccess.loadAsList(eq(0), Mockito.anyInt())).thenReturn(List.of(pollActivity, otherActivity));
+    when(activityManager.getActivitiesOfSpaceWithListAccess(any())).thenReturn(listAccess);
+
+    Poll poll = openPoll();
+    when(pollService.getPollById(eq(POLL_ID), any())).thenReturn(poll);
+    stubResults(poll, 2, 1, true);
+
+    List<PollResultModel> polls = pollMcpTool.listSpacePolls(SPACE_ID, null);
+
+    assertNotNull(polls);
+    assertEquals(1, polls.size());
+    assertEquals(POLL_ID, polls.get(0).getId());
+    assertEquals(3, polls.get(0).getTotalVotes());
+  }
+
+  @Test
+  void listSpacePollsUnknownSpaceFails() {
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(null);
+    assertThrows(IllegalArgumentException.class, () -> pollMcpTool.listSpacePolls(SPACE_ID, null));
+  }
+
+  @Test
+  void listSpacePollsNotMemberFails() {
+    Space space = new Space();
+    space.setId(String.valueOf(SPACE_ID));
+    space.setDisplayName("Engineering");
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+    when(spaceService.canViewSpace(eq(space), eq(USERNAME))).thenReturn(false);
+    assertThrows(IllegalStateException.class, () -> pollMcpTool.listSpacePolls(SPACE_ID, null));
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,21 @@
     <io.meeds.platform-ui.version>7.3.x-SNAPSHOT</io.meeds.platform-ui.version>
     <addon.meeds.analytics.version>7.3.x-SNAPSHOT</addon.meeds.analytics.version>
     <addon.meeds.gamification.version>7.3.x-SNAPSHOT</addon.meeds.gamification.version>
+    <addon.meeds.mcp-server.version>7.3.x-SNAPSHOT</addon.meeds.mcp-server.version>
 
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>
   </properties>
   <dependencyManagement>
     <dependencies>
+      <!-- Import versions from MCP Server project -->
+      <dependency>
+        <groupId>io.meeds.mcp-server</groupId>
+        <artifactId>mcp-server</artifactId>
+        <version>${addon.meeds.mcp-server.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- Import versions from platform project -->
       <dependency>
         <groupId>io.meeds.social</groupId>


### PR DESCRIPTION
Expose the Poll add-on to the AI agent (EVA) via 4 MCP tools in a new io.meeds.poll.mcp package (PollMcpTool + ai-tool-definitions.json):

- create_poll(space_id, question, options, duration, message) [approval]
- vote_in_poll(poll_option_id) [approval]
- get_poll_results(poll_id)
- list_space_polls(space_id, limit) — discovery, so a poll's id and option ids can be found from a space without guessing

Each tool acts as the current user, so space membership and redactor permissions enforced by PollService apply. Adds the mcp-server-tools provided dependency, the -parameters compiler flag and unit tests.


(cherry picked from commit aba3262799a87102e8757c6336ace7ca9da9f56f)